### PR TITLE
Aanmaak devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.12-slim
 
+# Set user and home as ENV variables
+ENV USERNAME=ceda \
+    WORKSPACE=/workspace \
+    USERHOME=/home/ceda
+
+
 # Install EVERYTHING - no more missing deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core compilers & tools
@@ -23,9 +29,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Skip arrow-dev (pyarrow uses wheels)
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv globally
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
 
-WORKDIR /workspace
+# Create non-root user with home directory, and ensure /workspace exists before chown
+RUN useradd -m "$USERNAME" -s /bin/bash \
+    && mkdir -p "$WORKSPACE" \
+    && chown -R "$USERNAME":"$USERNAME" "$WORKSPACE"
+
+# Install uv for the user
+USER $USERNAME
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="$USERHOME/.local/bin:${PATH}"
+
+WORKDIR $WORKSPACE
+USER $USERNAME
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,12 @@
 {
   "name": "1CijferHO",
   "build": { "dockerfile": "Dockerfile" },
-  "extensions": ["ms-python.python"],
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"]
+    }
+  },
+  "remoteUser": "ceda",
   "postCreateCommand": "uv sync",
   "forwardPorts": [8501]
 }


### PR DESCRIPTION
Deze PR introduceert een **devcontainer** voor het *1cijferho*-project. Hiermee kun je eenvoudig een consistente ontwikkelomgeving opzetten. De devcontainer kan op drie manieren worden gebruikt:

- **In Positron** bij het openen van het project  
- **In VS Code** bij het openen van het project  
- **In de terminal** met behulp van [DevPod](https://devpod.sh/)

> ⚙️ Voor alle methodes is **Docker** vereist op je systeem.

### Gebruik in Positron of VS Code
Bij het openen van het project zal de editor de onderstaande melding tonen:

<img width="475" height="134" alt="screenshot-20260206-100133Z" src="https://github.com/user-attachments/assets/d4fe9705-153b-4875-8ab8-38a66911b96f" />

Indien deze melding niet verschijnt, controleer dan of de extensie [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) is geïnstalleerd.

### Gebruik met DevPod
1. Navigeer in de terminal naar de hoofdmap van het project.  
2. Run `devpod up .` om de container te bouwen (eenmalig).  
3. Run vervolgens `devpod ssh` om verbinding te maken met de container.