### PR TITLE
feat: get_fwf_params en list_fwf_tables voor pandas.read_fwf() integratie

### DIFF
--- a/src/eencijferho/__init__.py
+++ b/src/eencijferho/__init__.py
@@ -15,7 +15,7 @@ Public API:
 __version__ = "0.1.0"
 
 from eencijferho.core.pipeline import run_turbo_convert_pipeline
-from eencijferho.core.extractor import process_txt_folder, write_variable_metadata, process_json_folder
+from eencijferho.core.extractor import process_txt_folder, write_variable_metadata, process_json_folder, get_fwf_params, list_fwf_tables
 from eencijferho.utils.converter_validation import converter_validation
 from eencijferho.utils.compressor import convert_csv_to_parquet
 from eencijferho.utils.encryptor import encryptor
@@ -35,4 +35,6 @@ __all__ = [
     "convert_csv_headers_to_snake_case",
     "validate_metadata_folder",
     "match_files",
+    "get_fwf_params",
+    "list_fwf_tables",
 ]

--- a/src/eencijferho/core/extractor.py
+++ b/src/eencijferho/core/extractor.py
@@ -720,6 +720,113 @@ def extract_excel_from_json(
     return results, files_created, total_tables
 
 
+def get_fwf_params(txt_file: str, table_index: int = 0) -> dict:
+    """Extract field names and column specs from a DUO bestandsbeschrijving .txt file.
+
+    Returns a dict that can be passed directly to ``pandas.read_fwf()`` as
+    keyword arguments, so no manual parsing of the fixed-width metadata is
+    needed::
+
+        import pandas as pd
+        from eencijferho import get_fwf_params
+
+        params = get_fwf_params("Bestandsbeschrijving_1cyferho_2023_v1.1.txt")
+        df = pd.read_fwf("1cyferho_2023.asc", encoding="latin-1", header=None, **params)
+
+    The ``colspecs`` values follow the pandas convention: 0-based, half-open
+    intervals ``[start, end)``.  ``Startpositie`` from DUO is 1-based, so
+    ``start = Startpositie - 1`` and ``end = Startpositie - 1 + Aantal posities``.
+
+    Args:
+        txt_file: Path to the DUO bestandsbeschrijving ``.txt`` (or ``.asc``) file.
+        table_index: Which table to use when the file contains multiple tables.
+            Defaults to 0 (the first / main table).
+
+    Returns:
+        ``{"names": list[str], "colspecs": list[tuple[int, int]]}``
+
+    Raises:
+        ValueError: When the file cannot be parsed, no tables are found, or
+            ``table_index`` is out of range.
+
+    Example::
+
+        >>> params = get_fwf_params("Bestandsbeschrijving_1cyferho_2023_v1.1.txt")
+        >>> params["names"][:3]
+        ['Onderwijstype HO', 'BRIN-nummer', 'Opleidingscode (CROHO)']
+        >>> params["colspecs"][:3]
+        [(0, 3), (3, 7), (7, 12)]
+    """
+    text = _read_txt_latin1(txt_file)
+    if text is None:
+        raise ValueError(f"Kan bestand niet lezen: {txt_file}")
+
+    tables = _parse_tables(text.split("\n"))
+    if not tables:
+        raise ValueError(f"Geen tabellen gevonden in {txt_file}")
+    if table_index >= len(tables):
+        raise ValueError(
+            f"table_index {table_index} buiten bereik — bestand heeft {len(tables)} tabel(len)"
+        )
+
+    table = tables[table_index]
+    content = table.get("content", [])
+    if not content:
+        raise ValueError(f"Tabel {table_index} heeft geen inhoud in {txt_file}")
+
+    header = content[0]
+    if "Startpositie" not in header or "Aantal posities" not in header:
+        raise ValueError(
+            f"Tabel {table_index} mist de verwachte kolomkoppen "
+            f"'Startpositie' / 'Aantal posities' in {txt_file}"
+        )
+
+    start_pos_index = header.find("Startpositie")
+    aantal_pos_index = header.find("Aantal posities")
+
+    names: list[str] = []
+    colspecs: list[tuple[int, int]] = []
+
+    for line in content[1:]:
+        if not line.strip():
+            continue
+        parsed = _parse_data_line(line, start_pos_index, aantal_pos_index)
+        if parsed is None:
+            continue
+        field_name, start_pos, aantal_pos, _comment = parsed
+        # DUO positions are 1-based; pandas.read_fwf expects 0-based half-open [start, end)
+        names.append(field_name)
+        colspecs.append((start_pos - 1, start_pos - 1 + aantal_pos))
+
+    if not names:
+        raise ValueError(f"Geen velden gevonden in tabel {table_index} van {txt_file}")
+
+    return {"names": names, "colspecs": colspecs}
+
+
+def list_fwf_tables(txt_file: str) -> list[str]:
+    """List the table names found in a DUO bestandsbeschrijving .txt file.
+
+    Useful for discovering which tables are available before calling
+    :func:`get_fwf_params` with a specific ``table_index``::
+
+        >>> list_fwf_tables("Bestandsbeschrijving_1cyferho_2023_v1.1.txt")
+        ['1CijferHO 2023']
+
+    Args:
+        txt_file: Path to the DUO bestandsbeschrijving ``.txt`` (or ``.asc``) file.
+
+    Returns:
+        List of table titles, in order.  Returns an empty list when the file
+        cannot be read or contains no tables.
+    """
+    text = _read_txt_latin1(txt_file)
+    if text is None:
+        return []
+    tables = _parse_tables(text.split("\n"))
+    return [t.get("table_title", f"untitled_table_{i}") for i, t in enumerate(tables)]
+
+
 def process_json_folder(
     json_input_folder: str = "data/00-metadata/json",
     excel_output_folder: str = "data/00-metadata",

--- a/tests/eencijferho/core/test_extractor.py
+++ b/tests/eencijferho/core/test_extractor.py
@@ -8,6 +8,8 @@ import pytest
 from eencijferho.core.extractor import (
     extract_tables_from_txt,
     process_txt_folder,
+    get_fwf_params,
+    list_fwf_tables,
     _find_title_above,
     _parse_tables,
     _parse_data_line,
@@ -301,3 +303,134 @@ def test_write_table_excel_with_decoding_variables(tmp_path):
     import pandas as pd
     sheets = pd.ExcelFile(out).sheet_names
     assert "DecodingVariables" in sheets
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_fwf_txt(path: Path, fields: list[tuple[str, int, int]]) -> Path:
+    """Write a minimal DUO bestandsbeschrijving with the given (name, start, length) fields."""
+    header = "Naam                  Startpositie  Aantal posities"
+    sp = header.find("Startpositie")
+    ap = header.find("Aantal posities")
+    lines = [
+        "TestTabel",
+        "================",
+        header,
+    ]
+    for name, start, length in fields:
+        # Pad name to startpositie column, then right-align numbers
+        padded = name.ljust(sp)
+        start_str = str(start).ljust(ap - sp)
+        lines.append(f"{padded}{start_str}{length}")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="latin-1")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# get_fwf_params
+# ---------------------------------------------------------------------------
+
+
+def test_get_fwf_params_returns_names_and_colspecs(tmp_path):
+    txt = _make_fwf_txt(
+        tmp_path / "Bestandsbeschrijving_test.txt",
+        [("VeldA", 1, 3), ("VeldB", 4, 2)],
+    )
+    params = get_fwf_params(str(txt))
+    assert params["names"] == ["VeldA", "VeldB"]
+    assert params["colspecs"] == [(0, 3), (3, 5)]
+
+
+def test_get_fwf_params_colspecs_zero_based(tmp_path):
+    """Startpositie 1 → colspec start 0 (DUO is 1-based, pandas is 0-based)."""
+    txt = _make_fwf_txt(tmp_path / "Bestandsbeschrijving_test.txt", [("Veld", 1, 5)])
+    params = get_fwf_params(str(txt))
+    assert params["colspecs"][0] == (0, 5)
+
+
+def test_get_fwf_params_single_field(tmp_path):
+    txt = _make_fwf_txt(tmp_path / "Bestandsbeschrijving_test.txt", [("Enkel", 3, 4)])
+    params = get_fwf_params(str(txt))
+    assert params["names"] == ["Enkel"]
+    assert params["colspecs"] == [(2, 6)]
+
+
+def test_get_fwf_params_raises_for_missing_file(tmp_path):
+    with pytest.raises(ValueError, match="niet lezen"):
+        get_fwf_params(str(tmp_path / "bestaat_niet.txt"))
+
+
+def test_get_fwf_params_raises_for_no_tables(tmp_path):
+    txt = tmp_path / "Bestandsbeschrijving_leeg.txt"
+    txt.write_text("Geen tabellen\n", encoding="latin-1")
+    with pytest.raises(ValueError, match="Geen tabellen"):
+        get_fwf_params(str(txt))
+
+
+def test_get_fwf_params_raises_for_invalid_table_index(tmp_path):
+    txt = _make_fwf_txt(tmp_path / "Bestandsbeschrijving_test.txt", [("VeldA", 1, 3)])
+    with pytest.raises(ValueError, match="buiten bereik"):
+        get_fwf_params(str(txt), table_index=99)
+
+
+def test_get_fwf_params_keys_are_names_and_colspecs(tmp_path):
+    txt = _make_fwf_txt(tmp_path / "Bestandsbeschrijving_test.txt", [("VeldA", 1, 3)])
+    params = get_fwf_params(str(txt))
+    assert set(params.keys()) == {"names", "colspecs"}
+
+
+def test_get_fwf_params_names_and_colspecs_same_length(tmp_path):
+    txt = _make_fwf_txt(
+        tmp_path / "Bestandsbeschrijving_test.txt",
+        [("A", 1, 2), ("B", 3, 4), ("C", 7, 1)],
+    )
+    params = get_fwf_params(str(txt))
+    assert len(params["names"]) == len(params["colspecs"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# list_fwf_tables
+# ---------------------------------------------------------------------------
+
+
+def test_list_fwf_tables_single_table(tmp_path):
+    txt = _make_fwf_txt(tmp_path / "Bestandsbeschrijving_test.txt", [("VeldA", 1, 3)])
+    names = list_fwf_tables(str(txt))
+    assert names == ["TestTabel"]
+
+
+def test_list_fwf_tables_two_tables(tmp_path):
+    header = "Naam                  Startpositie  Aantal posities"
+    sp = header.find("Startpositie")
+    content = "\n".join([
+        "TabelEen",
+        "================",
+        header,
+        "VeldA".ljust(sp) + "1             3",
+        "",
+        "TabelTwee",
+        "================",
+        header,
+        "VeldB".ljust(sp) + "1             5",
+        "",
+    ])
+    txt = tmp_path / "Bestandsbeschrijving_multi.txt"
+    txt.write_text(content, encoding="latin-1")
+    names = list_fwf_tables(str(txt))
+    assert names == ["TabelEen", "TabelTwee"]
+
+
+def test_list_fwf_tables_returns_empty_for_missing_file(tmp_path):
+    result = list_fwf_tables(str(tmp_path / "bestaat_niet.txt"))
+    assert result == []
+
+
+def test_list_fwf_tables_returns_empty_for_no_tables(tmp_path):
+    txt = tmp_path / "Bestandsbeschrijving_leeg.txt"
+    txt.write_text("Geen tabellen\n", encoding="latin-1")
+    result = list_fwf_tables(str(txt))
+    assert result == []


### PR DESCRIPTION
## Summary

- Voegt `get_fwf_params(txt_file, table_index=0)` toe als publieke API: extraheert veldnamen en colspecs uit een DUO bestandsbeschrijving `.txt`, direct bruikbaar als kwargs voor `pandas.read_fwf()`
- Voegt `list_fwf_tables(txt_file)` toe als discovery helper: toont welke tabellen in een bestandsbeschrijving zitten
- Beide functies geëxporteerd vanuit `eencijferho` (pip-installeerbaar)

**Gebruik:**
```python
from eencijferho import get_fwf_params
import pandas as pd

params = get_fwf_params("Bestandsbeschrijving_1cyferho_2023_v1.1.txt")
df = pd.read_fwf("1cyferho_2023.asc", encoding="latin-1", header=None, **params)
```

## Achtergrond

Op verzoek van externe gebruikers die de 1CHO data willen inlezen in hun eigen datastraat (pip/poetry) zonder de volledige Streamlit/CLI-pipeline te gebruiken.

## Test plan

- [ ] `uv run pytest tests/eencijferho/core/test_extractor.py` — 40 tests, inclusief 12 nieuwe voor `get_fwf_params` en `list_fwf_tables`
- [ ] Handmatig testen met demo-bestand: `get_fwf_params("data/01-input/DEMO/Bestandsbeschrijving_1cyferho_2023_v1.1_DEMO.txt")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)