### PR TITLE
feat: documentatielink toevoegen aan PyPI en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     <img src="https://badgen.net/github/last-commit/cedanl/1cijferho" alt="GitHub Last Commit">
     <img src="https://badgen.net/github/contributors/cedanl/1cijferho" alt="Contributors">
     <img src="https://img.shields.io/github/license/cedanl/1cijferho" alt="GitHub License">
+    <a href="https://cedanl.github.io/1cijferho/"><img src="https://img.shields.io/badge/docs-mkdocs-teal" alt="Documentatie"></a>
   </p>
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/cedanl/1cijferho"
+Documentation = "https://cedanl.github.io/1cijferho/"
 Repository = "https://github.com/cedanl/1cijferho"
 Issues = "https://github.com/cedanl/1cijferho/issues"
 


### PR DESCRIPTION
## Summary

- `pyproject.toml`: `Documentation` URL toegevoegd — verschijnt als link op de PyPI-pagina
- `README.md`: docs badge toegevoegd naast de bestaande badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)