### PR TITLE
fix: Windows-padproblemen in bestandskoppeling en Turbo Convert (#134)

### DIFF
--- a/src/eencijferho/cli.py
+++ b/src/eencijferho/cli.py
@@ -200,7 +200,7 @@ def cmd_decode(storage, args: argparse.Namespace) -> None:
 
     count = 0
     for filepath in storage.list_files(f"{args.output}/*.csv"):
-        fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        fname = os.path.basename(filepath)
         if not (
             (fname.startswith("EV") or fname.startswith("VAKHAVW"))
             and fname.endswith(".csv")
@@ -241,7 +241,7 @@ def cmd_enrich(storage, args: argparse.Namespace) -> None:
 
     written = skipped = 0
     for filepath in storage.list_files(f"{args.output}/*_decoded.csv"):
-        fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        fname = os.path.basename(filepath)
         if fname.endswith("_decoded_encrypted.csv"):
             continue
         base = filepath.replace("_decoded.csv", ".csv")

--- a/src/eencijferho/core/extractor.py
+++ b/src/eencijferho/core/extractor.py
@@ -272,7 +272,7 @@ def process_txt_folder(
     # Get all files from input folder and filter
     all_files = storage.list_files(f"{input_folder}/*")
     for filepath in all_files:
-        filename = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        filename = os.path.basename(filepath)
         file_is_txt = filename.endswith(".txt") and filter_keyword in filename
         file_is_asc = filename.endswith(".asc")
 
@@ -898,7 +898,7 @@ def process_json_folder(
     total_row_mismatches = 0
 
     for json_file in json_files:
-        file_name = json_file.rsplit("/", 1)[-1] if "/" in json_file else json_file
+        file_name = os.path.basename(json_file)
 
         # Log file processing
         file_log = {"file": file_name, "status": "processing", "tables": []}

--- a/src/eencijferho/core/pipeline.py
+++ b/src/eencijferho/core/pipeline.py
@@ -97,7 +97,7 @@ def run_turbo_convert_pipeline(
     if do_decode or do_enrich:
         csv_files = storage.list_files(f"{dec_dir}/*.csv")
         for filepath in csv_files:
-            filename = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+            filename = os.path.basename(filepath)
             if not (
                 (filename.startswith("EV") or filename.startswith("VAKHAVW"))
                 and filename.endswith(".csv")
@@ -163,7 +163,7 @@ def run_turbo_convert_pipeline(
         en.encryptor(output_dir, output_dir)
         encrypted_files = storage.list_files(f"{output_dir}/*_encrypted.csv")
         for enc_path in encrypted_files:
-            fname = enc_path.rsplit("/", 1)[-1] if "/" in enc_path else enc_path
+            fname = os.path.basename(enc_path)
             original_name = fname.replace("_encrypted.csv", ".csv")
             original_path = f"{output_dir}/{original_name}"
             if storage.exists(original_path):
@@ -193,7 +193,7 @@ def run_turbo_convert_pipeline(
     output_files = []
     all_output = storage.list_files(f"{output_dir}/*")
     for filepath in all_output:
-        filename = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        filename = os.path.basename(filepath)
         try:
             size = len(storage.read_bytes(filepath))
         except Exception:

--- a/src/eencijferho/utils/compressor.py
+++ b/src/eencijferho/utils/compressor.py
@@ -1,3 +1,4 @@
+import os
 from rich.console import Console
 from rich.progress import track
 
@@ -16,7 +17,7 @@ def convert_csv_to_parquet(storage, input_dir: str | None = None) -> None:
 
     for csv_file in track(csv_files, description="Converting files"):
         # Skip Dec lookup table files (Dec_*.csv) — not output data files
-        filename = csv_file.rsplit("/", 1)[-1] if "/" in csv_file else csv_file
+        filename = os.path.basename(csv_file)
         if filename.lower().startswith("dec_"):
             console.print(f"[yellow]↷[/] Skipping {filename}")
             continue

--- a/src/eencijferho/utils/converter_headers.py
+++ b/src/eencijferho/utils/converter_headers.py
@@ -1,3 +1,4 @@
+import os
 import polars as pl
 import re
 import unicodedata
@@ -94,7 +95,7 @@ def convert_csv_headers_to_snake_case(
     failed_files = []
 
     for filepath in csv_files:
-        fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        fname = os.path.basename(filepath)
         try:
             console.print(f"Processing: [bold]{fname}[/bold]")
 

--- a/src/eencijferho/utils/converter_match.py
+++ b/src/eencijferho/utils/converter_match.py
@@ -33,7 +33,7 @@ def load_input_files(storage, input_folder: str) -> pl.DataFrame:
 
     all_files = storage.list_files(f"{input_folder}/*")
     for filepath in all_files:
-        filename = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        filename = os.path.basename(filepath)
         if filename.lower().endswith(('.txt', '.zip', '.xlsx', '.docx', '.csv')):
             continue
         files.append(filename)
@@ -120,14 +120,11 @@ def match_files(storage, input_folder: str, log_path: str = "data/00-metadata/lo
 
         # Apply special matching rules based on input filename
         if input_file.startswith("EV"):
-            # For files starting with "EV", match with files containing "1cyferho"
-            matches = validation_df.filter(pl.col("file").str.contains("1cyferho"))
+            matches = validation_df.filter(pl.col("file").str.contains("1cyferho", literal=True))
         elif "VAKHAVW" in input_file:
-            # For files containing "VAKHAVW", match with files containing "Vakgegevens"
-            matches = validation_df.filter(pl.col("file").str.contains("Vakgegevens"))
+            matches = validation_df.filter(pl.col("file").str.contains("Vakgegevens", literal=True))
         else:
-            # Default matching: find where input_file is contained in the 'file' column
-            matches = validation_df.filter(pl.col("file").str.contains(input_file))
+            matches = validation_df.filter(pl.col("file").str.contains(input_file, literal=True))
 
         file_log = {
             "input_file": input_file,

--- a/src/eencijferho/utils/encryptor.py
+++ b/src/eencijferho/utils/encryptor.py
@@ -28,7 +28,7 @@ def encryptor(storage, input_dir: str | None = None, output_dir: str | None = No
 
     from eencijferho.utils.converter_headers import clean_header_name
     for filepath in target_files:
-        fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        fname = os.path.basename(filepath)
         try:
             # Always read as UTF-8 (mirroring decoded output)
             df = storage.read_dataframe(filepath, format="csv", infer_schema_length=0)

--- a/src/eencijferho/utils/extractor_validation.py
+++ b/src/eencijferho/utils/extractor_validation.py
@@ -220,7 +220,7 @@ def validate_metadata_folder(storage, metadata_folder: str = "data/00-metadata",
     # Validate each file
     results = {}
     for file_path in excel_files:
-        file_name = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
+        file_name = os.path.basename(file_path)
 
         # Log file processing
         file_log = {

--- a/src/eencijferho/utils/snapshot_validator.py
+++ b/src/eencijferho/utils/snapshot_validator.py
@@ -36,7 +36,7 @@ _ENCRYPTED_COLS = {"persoonsgebonden_nummer", "burgerservicenummer", "onderwijsn
 
 def _scan_file(storage, filepath: str) -> dict:
     """Return snapshot metadata for a single file."""
-    fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+    fname = os.path.basename(filepath)
     ext = fname.rsplit(".", 1)[-1].lower() if "." in fname else ""
     entry: dict = {}
 
@@ -96,7 +96,7 @@ def generate_snapshot(storage, output_dir: str, snapshot_path: str) -> None:
     }
 
     for filepath in sorted(files):
-        fname = filepath.rsplit("/", 1)[-1] if "/" in filepath else filepath
+        fname = os.path.basename(filepath)
         _console.print(f"  [dim]Scanning {fname}[/dim]")
         snapshot["files"][fname] = _scan_file(storage, filepath)
 
@@ -130,7 +130,7 @@ def validate_snapshot(
         if "/metadata/" not in f and "\\metadata\\" not in f
     ]
     current_map = {
-        (f.rsplit("/", 1)[-1] if "/" in f else f): f for f in current_files
+        os.path.basename(f): f for f in current_files
     }
     expected_names = set(expected["files"].keys())
     current_names = set(current_map.keys())


### PR DESCRIPTION
## Summary

Twee samenhangende Windows-padbugs gerepareerd die samen ervoor zorgden dat Turbo Convert op Windows volledig faalde (0 bestanden succesvol omgezet).

**Bug 1 — regex crash bij bestandskoppeling (`converter_match.py`)**
- `rsplit("/", 1)` splitst niet op Windows (backslash-paden), waardoor de volledige pad als bestandsnaam werd opgeslagen
- Die pad (`data\01-input\DEMO\Croho.asc`) belandde als regex-patroon in Polars `str.contains()` → crash op `\0` als backreference

**Bug 2 — dubbele padprefix bij Turbo Convert (`extractor_validation.py` + `converter.py`)**
- `extractor_validation.py` sloeg de volledige pad op in de xlsx-validatielog i.p.v. alleen de bestandsnaam
- `converter.py` voegde daar `metadata_folder` aan toe → `data/00-metadata\data/00-metadata\Bestandsbeschrijving_...xlsx` → niet gevonden

**Structural fix — alle 14 instanties (`rsplit` → `os.path.basename`)**
- Hetzelfde `rsplit("/", 1)[-1] if "/" in x else x` patroon stond verspreid over 8 bestanden
- Vervangen door `os.path.basename()` (cross-platform, stdlib)
- `import os` toegevoegd aan `compressor.py` en `converter_headers.py`

## Gewijzigde bestanden
- `src/eencijferho/utils/converter_match.py` — rsplit + literal=True op str.contains
- `src/eencijferho/utils/extractor_validation.py` — rsplit fix (kern van bug 2)
- `src/eencijferho/utils/compressor.py`
- `src/eencijferho/utils/converter_headers.py`
- `src/eencijferho/utils/encryptor.py`
- `src/eencijferho/utils/snapshot_validator.py`
- `src/eencijferho/core/extractor.py`
- `src/eencijferho/core/pipeline.py`
- `src/eencijferho/cli.py`

## Test plan
- [ ] Windows: validatie doorloopt zonder regex error
- [ ] Windows: Turbo Convert zet bestanden succesvol om (was 0/14)
- [ ] Linux: bestaande werking ongewijzigd (rsplit en basename geven zelfde resultaat op Linux)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)