### PR TITLE
feat: preset-configuraties voor Turbo Convert (nfwa)

### DIFF
--- a/src/eencijferho/cli.py
+++ b/src/eencijferho/cli.py
@@ -48,6 +48,7 @@ from eencijferho.core.extractor import (
 )
 from eencijferho.core.pipeline import run_turbo_convert_pipeline
 from eencijferho.config import OutputConfig
+from eencijferho.presets import PRESET_CONFIGS
 from eencijferho.utils.converter_headers import clean_header_name, normalize_name
 from eencijferho.utils.converter_match import match_files
 from eencijferho.utils.extractor_validation import validate_metadata_folder
@@ -270,7 +271,32 @@ def cmd_enrich(storage, args: argparse.Namespace) -> None:
 
 
 def _build_output_config(args: argparse.Namespace) -> OutputConfig:
-    """Build an OutputConfig from CLI flags."""
+    """Build an OutputConfig from CLI flags, with optional preset override."""
+    preset_name = getattr(args, "preset", None)
+    if preset_name:
+        cfg = PRESET_CONFIGS.get(preset_name)
+        if cfg is None:
+            available = [k for k, v in PRESET_CONFIGS.items() if v["available"] and k != "custom"]
+            raise SystemExit(f"Onbekende preset '{preset_name}'. Beschikbaar: {', '.join(available)}")
+        if not cfg["available"]:
+            raise SystemExit(f"Preset '{preset_name}' is nog niet beschikbaar.")
+        s = cfg["settings"]
+        variants = []
+        if s["opt_decoded"]:
+            variants.append("decoded")
+            if s["opt_enriched"]:
+                variants.append("enriched")
+        return OutputConfig(
+            variants=variants,
+            formats=["parquet"] if s["opt_parquet"] else [],
+            encrypt=s["opt_encrypt"],
+            column_casing="snake_case" if s["opt_snake_case"] else "none",
+            convert_ev=s["opt_convert_ev"],
+            convert_vakhavw=s["opt_convert_vakhavw"],
+            decode_columns=s["decode_columns"],
+            enrich_variables=s["enrich_variables"],
+        )
+
     variants = []
     if not args.skip_decode:
         variants.append("decoded")
@@ -386,6 +412,13 @@ def main() -> None:
         "--enrich-variables", nargs="*", metavar="VARIABELE", default=None,
         help="Alleen deze variabelen verrijken via variable_metadata (standaard: alle). "
              "Gebruik get_available_enrich_variables() om geldige namen te achterhalen.",
+    )
+    available_presets = [k for k, v in PRESET_CONFIGS.items() if v["available"] and k != "custom"]
+    _output_opts.add_argument(
+        "--preset", metavar="NAAM", default=None,
+        choices=available_presets,
+        help=f"Laad een vooraf gedefinieerde configuratie. Overschrijft alle andere uitvoeropties. "
+             f"Beschikbaar: {', '.join(available_presets)}.",
     )
 
     subparsers.add_parser(

--- a/src/eencijferho/presets.py
+++ b/src/eencijferho/presets.py
@@ -20,8 +20,8 @@ PRESET_CONFIGS: dict[str, dict] = {
             "opt_parquet": True,
             "opt_encrypt": True,
             "opt_snake_case": True,
-            "decode_columns": ["geslacht", "vooropleiding", "aansluiting"],
-            "enrich_variables": ["geslacht", "vooropleiding", "aansluiting"],
+            "decode_columns": ["Hoogste vooropleiding vï¿½ï¿½r het HO"],
+            "enrich_variables": ["Geslacht", "Hoogste vooropleiding vóór het HO"],
         },
     },
     "svo": {

--- a/src/eencijferho/presets.py
+++ b/src/eencijferho/presets.py
@@ -1,0 +1,33 @@
+PRESET_CONFIGS: dict[str, dict] = {
+    "custom": {
+        "label": "Eigen instellingen",
+        "description": None,
+        "available": True,
+        "settings": None,
+    },
+    "nfwa": {
+        "label": "No Fairness Without Awareness",
+        "description": (
+            "Configuratie voor het NFWA-project (CEDA/Npuls). "
+            "Alleen EV-bestanden; geslacht, vooropleiding en aansluiting gedecodeerd en verrijkt."
+        ),
+        "available": True,
+        "settings": {
+            "opt_convert_ev": True,
+            "opt_convert_vakhavw": False,
+            "opt_decoded": True,
+            "opt_enriched": True,
+            "opt_parquet": True,
+            "opt_encrypt": True,
+            "opt_snake_case": True,
+            "decode_columns": ["geslacht", "vooropleiding", "aansluiting"],
+            "enrich_variables": ["geslacht", "vooropleiding", "aansluiting"],
+        },
+    },
+    "svo": {
+        "label": "Staat van het Onderwijs",
+        "description": "Binnenkort beschikbaar.",
+        "available": False,
+        "settings": None,
+    },
+}

--- a/src/eencijferho/presets.py
+++ b/src/eencijferho/presets.py
@@ -14,7 +14,7 @@ PRESET_CONFIGS: dict[str, dict] = {
         "available": True,
         "settings": {
             "opt_convert_ev": True,
-            "opt_convert_vakhavw": False,
+            "opt_convert_vakhavw": True,
             "opt_decoded": True,
             "opt_enriched": True,
             "opt_parquet": True,

--- a/src/eencijferho/presets.py
+++ b/src/eencijferho/presets.py
@@ -9,7 +9,7 @@ PRESET_CONFIGS: dict[str, dict] = {
         "label": "No Fairness Without Awareness",
         "description": (
             "Configuratie voor het NFWA-project (CEDA/Npuls). "
-            "Alleen EV-bestanden; geslacht, vooropleiding en aansluiting gedecodeerd en verrijkt."
+            "Alleen EV-bestanden; geslacht en hoogste vooropleiding vóór het HO gedecodeerd en verrijkt."
         ),
         "available": True,
         "settings": {

--- a/src/eencijferho/presets.py
+++ b/src/eencijferho/presets.py
@@ -20,7 +20,7 @@ PRESET_CONFIGS: dict[str, dict] = {
             "opt_parquet": True,
             "opt_encrypt": True,
             "opt_snake_case": True,
-            "decode_columns": ["Hoogste vooropleiding vï¿½ï¿½r het HO"],
+            "decode_columns": ["Hoogste vooropleiding vï¿½ï¿½r het HO", "Hoogste vooropleiding", "Opleidingscode"],
             "enrich_variables": ["Geslacht", "Hoogste vooropleiding vóór het HO"],
         },
     },

--- a/src/frontend/Modules/Turbo_Convert.py
+++ b/src/frontend/Modules/Turbo_Convert.py
@@ -14,6 +14,7 @@ from eencijferho.core.decoder_info import (
 )
 from typing import Any
 from config import get_input_dir, get_output_dir, get_metadata_dir
+from eencijferho.presets import PRESET_CONFIGS
 
 # -----------------------------------------------------------------------------
 # Page Configuration
@@ -301,6 +302,33 @@ else:
     if successful_pairs:
         st.divider()
         st.markdown("#### Uitvoeropties")
+
+        # --- Preset selector ---
+        st.radio(
+            "Instelmodus",
+            options=list(PRESET_CONFIGS.keys()),
+            format_func=lambda k: PRESET_CONFIGS[k]["label"]
+            if PRESET_CONFIGS[k]["available"]
+            else f"{PRESET_CONFIGS[k]['label']} (binnenkort beschikbaar)",
+            key="opt_preset",
+            horizontal=True,
+        )
+        active_preset = st.session_state.get("opt_preset", "custom")
+        preset_cfg = PRESET_CONFIGS[active_preset]
+        is_preset = active_preset != "custom" and preset_cfg["available"]
+
+        if is_preset:
+            st.info(preset_cfg["description"])
+            s = preset_cfg["settings"]
+            for _key in (
+                "opt_convert_ev", "opt_convert_vakhavw", "opt_decoded",
+                "opt_enriched", "opt_parquet", "opt_encrypt", "opt_snake_case",
+            ):
+                st.session_state[_key] = s[_key]
+
+        if active_preset == "svo":
+            st.warning("Deze preset is nog niet beschikbaar. Kies 'Eigen instellingen' om handmatig te configureren.")
+
         st.caption("Standaardinstellingen zijn geschikt voor de meeste gebruikers.")
 
         # --- Groep 1: Welke bestanden ---
@@ -309,10 +337,12 @@ else:
         with col_ev:
             st.checkbox(
                 "EV-bestanden", value=True, key="opt_convert_ev",
+                disabled=is_preset,
                 help="Zet de EV-hoofdbestanden om van vaste-breedte naar CSV.")
         with col_vak:
             st.checkbox(
                 "VAKHAVW-bestanden", value=True, key="opt_convert_vakhavw",
+                disabled=is_preset,
                 help="Zet de VAKHAVW-hoofdbestanden om van vaste-breedte naar CSV.")
         no_main_files = (
             not st.session_state.get("opt_convert_ev", True)
@@ -328,7 +358,7 @@ else:
             st.checkbox(
                 "Gedecodeerde variant",
                 value=True, key="opt_decoded",
-                disabled=no_main_files,
+                disabled=is_preset or no_main_files,
                 help="Voegt omschrijvingen toe vanuit Dec_*-bestanden (bijv. `landcode` → `landcode_oms`).")
             st.caption("`_decoded`")
         with col_enr:
@@ -336,7 +366,7 @@ else:
             st.checkbox(
                 "Verrijkte variant",
                 value=True, key="opt_enriched",
-                disabled=no_main_files or not _decoded_on,
+                disabled=is_preset or no_main_files or not _decoded_on,
                 help="Vervangt codes door leesbare labels (bijv. `M` → `man`). Vereist gedecodeerde variant.")
             if not _decoded_on or no_main_files:
                 st.caption("`_enriched` — vereist decoded")
@@ -352,27 +382,36 @@ else:
 
         if show_decode:
             if available_decode:
-                n_decode_selected = sum(
-                    1 for col in available_decode if _decode_sel.get(col, True)
-                )
-                non_default_parts = []
-                if n_decode_selected < len(available_decode):
-                    non_default_parts.append(f"{n_decode_selected}/{len(available_decode)} decode")
-                if show_enrich and available_enrich:
-                    n_enrich_selected = sum(
-                        1 for var in available_enrich if _enrich_sel.get(var, True)
+                if is_preset:
+                    cols_label = ", ".join(preset_cfg["settings"]["decode_columns"])
+                    st.button(
+                        "Kolomselectie instellen →",
+                        key="configure_columns_btn",
+                        disabled=True,
+                        help=f"Preset selecteert: {cols_label}",
                     )
-                    if n_enrich_selected < len(available_enrich):
-                        non_default_parts.append(f"{n_enrich_selected}/{len(available_enrich)} verrijken")
-                btn_label = "Kolomselectie instellen →"
-                if non_default_parts:
-                    btn_label += f" ({' · '.join(non_default_parts)})"
-                if st.button(
-                    btn_label,
-                    key="configure_columns_btn",
-                    help="Kies welke kolommen worden gedecodeerd en verrijkt.",
-                ):
-                    configure_columns_dialog(available_decode, available_enrich, decode_info, enrich_info, show_decode, show_enrich)
+                else:
+                    n_decode_selected = sum(
+                        1 for col in available_decode if _decode_sel.get(col, True)
+                    )
+                    non_default_parts = []
+                    if n_decode_selected < len(available_decode):
+                        non_default_parts.append(f"{n_decode_selected}/{len(available_decode)} decode")
+                    if show_enrich and available_enrich:
+                        n_enrich_selected = sum(
+                            1 for var in available_enrich if _enrich_sel.get(var, True)
+                        )
+                        if n_enrich_selected < len(available_enrich):
+                            non_default_parts.append(f"{n_enrich_selected}/{len(available_enrich)} verrijken")
+                    btn_label = "Kolomselectie instellen →"
+                    if non_default_parts:
+                        btn_label += f" ({' · '.join(non_default_parts)})"
+                    if st.button(
+                        btn_label,
+                        key="configure_columns_btn",
+                        help="Kies welke kolommen worden gedecodeerd en verrijkt.",
+                    ):
+                        configure_columns_dialog(available_decode, available_enrich, decode_info, enrich_info, show_decode, show_enrich)
             else:
                 st.caption("Kolomselectie beschikbaar nadat metadata is geëxtraheerd.")
 
@@ -384,25 +423,32 @@ else:
         with col_p:
             st.checkbox(
                 "Parquet", value=True, key="opt_parquet",
+                disabled=is_preset,
                 help="Slaat elk CSV-bestand ook op als Parquet (60–80% kleiner, sneller te laden).")
         with col_e:
             st.checkbox(
                 "Versleutelen", value=True, key="opt_encrypt",
+                disabled=is_preset,
                 help="Maakt een aparte versleutelde kopie voor bestanden met gevoelige kolommen (BSN).")
         with col_s:
             st.checkbox(
                 "snake_case", value=True, key="opt_snake_case",
+                disabled=is_preset,
                 help="Converteert kolomnamen naar snake_case (bijv. `Naam Student` → `naam_student`).")
 
         # Compute opt_decode_columns / opt_enrich_variables from stable dicts
-        if show_decode and available_decode:
-            selected_decode = [col for col in available_decode if _decode_sel.get(col, True)]
-            if len(selected_decode) < len(available_decode):
-                opt_decode_columns = selected_decode
-        if show_enrich and available_enrich:
-            selected_enrich = [var for var in available_enrich if _enrich_sel.get(var, True)]
-            if len(selected_enrich) < len(available_enrich):
-                opt_enrich_variables = selected_enrich
+        if is_preset:
+            opt_decode_columns = preset_cfg["settings"]["decode_columns"]
+            opt_enrich_variables = preset_cfg["settings"]["enrich_variables"]
+        else:
+            if show_decode and available_decode:
+                selected_decode = [col for col in available_decode if _decode_sel.get(col, True)]
+                if len(selected_decode) < len(available_decode):
+                    opt_decode_columns = selected_decode
+            if show_enrich and available_enrich:
+                selected_enrich = [var for var in available_enrich if _enrich_sel.get(var, True)]
+                if len(selected_enrich) < len(available_enrich):
+                    opt_enrich_variables = selected_enrich
 
     # Warning about existing converted files — shown before the action button
     if os.path.exists(get_output_dir()) and any(f for f in os.listdir(get_output_dir()) if not f.startswith(".")):


### PR DESCRIPTION
## Samenvatting

Voegt een preset-selector toe aan de Turbo Convert-pagina (issue #139). Gebruikers kunnen nu met één klik een vooraf gedefinieerde configuratie laden, zonder zelf te hoeven uitzoeken welke opties nodig zijn voor hun onderzoeksproduct.

**Wijzigingen:**
- Nieuw `src/eencijferho/presets.py` — centrale preset-definities (nfwa actief, svo als placeholder)
- `Turbo_Convert.py` — radio-selector bovenaan opties; alle 7 checkboxes worden grijs + info-banner bij actieve preset; kolomselectie-knop disabled met tooltip
- `cli.py` — `--preset nfwa` vlag voor `convert` en `pipeline` subcommands

**nfwa-configuratie** (afgeleid van [variabelen.csv](https://github.com/cedanl/no-fairness-without-awareness/blob/main/inst/metadata/variabelen.csv)):
- Alleen EV-bestanden (VAKHAVW uit)
- Decoded + Enriched variant
- Decode-kolommen: `geslacht`, `vooropleiding`, `aansluiting`
- Parquet, versleutelen, snake_case aan

## Testplan

- [ ] Start app: `uv run streamlit run src/main.py`
- [ ] Selecteer "No Fairness Without Awareness" → checkboxes grijs, correct ingesteld, kolomselectie-knop disabled met tooltip
- [ ] Selecteer "Staat van het Onderwijs" → waarschuwing "binnenkort beschikbaar"
- [ ] Selecteer "Eigen instellingen" → alles interactief
- [ ] CLI: `eencijferho convert --input ... --output ... --preset nfwa` werkt
- [ ] CLI: `eencijferho convert --help` toont `--preset NAAM`

## Gerelateerde issues

Sluit #140 (nfwa preset)
Onderdeel van #139 (hoofd-issue)
SVO-preset volgt via #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)