### PR TITLE
feat: client-side encryptie demo met één-knop opslag naar MinIO + Postgres

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests with coverage
+        run: uv run pytest tests/eencijferho/ --cov=eencijferho --cov-report=xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
@@ -32,3 +46,5 @@ jobs:
             -Dsonar.organization=cedanl
             -Dsonar.python.version=3.13
             -Dsonar.sources=src/
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.coverage.exclusions=src/frontend/**,src/main.py,src/eencijferho/io/backends/**

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,11 +15,46 @@ jobs:
     permissions:
       contents: read
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: cijferho
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:9000/minio/health/live && break
+            echo "Waiting for MinIO... ($i)"
+            sleep 1
+          done
+
+      - name: Create MinIO test bucket
+        run: |
+          curl -LsSf https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+          chmod +x /usr/local/bin/mc
+          mc alias set local http://localhost:9000 minioadmin minioadmin
+          mc mb local/1cijferho-test --ignore-existing
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -29,11 +64,14 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install dependencies
-        run: uv sync --group dev
+      - name: Install dependencies (with backends for integration tests)
+        run: uv sync --group dev --extra minio --extra postgres
 
-      - name: Run tests with coverage
-        run: uv run pytest tests/eencijferho/ --cov=eencijferho --cov-report=xml
+      - name: Run unit tests with coverage
+        run: uv run pytest tests/eencijferho/ --cov=eencijferho --cov-report=
+
+      - name: Run integration tests with coverage (append)
+        run: uv run pytest tests/integration/ --cov=eencijferho --cov-append --cov-report=xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
@@ -47,4 +85,4 @@ jobs:
             -Dsonar.python.version=3.13
             -Dsonar.sources=src/
             -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.coverage.exclusions=src/frontend/**,src/main.py,src/eencijferho/io/backends/**
+            -Dsonar.coverage.exclusions=src/frontend/**,src/main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ RUN useradd -m $USER
 WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra frontend --extra all-backends
+RUN uv sync --frozen --no-dev --no-install-project --extra frontend --extra all-backends
 
 COPY src ./src
 COPY data ./data
+
+RUN uv sync --frozen --no-dev --extra frontend --extra all-backends
 
 RUN chown -R $USER:$USER /app
 USER $USER

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,41 @@
+-- Personal-data demo schema for 1CijferHO.
+-- Loaded by the postgres container on first start
+-- (mounted into /docker-entrypoint-initdb.d via docker-compose).
+--
+-- secret_sensitive : UUID + encrypted personal identifiers
+-- secret_regular   : UUID + demographic fields (1:1 with secret_sensitive)
+-- Non-sensitive fields are stored separately as a JSON object in MinIO.
+
+CREATE TABLE IF NOT EXISTS secret_sensitive (
+    uuid TEXT PRIMARY KEY,
+    persoonsgebonden_nummer TEXT,
+    burgerservice_nummer TEXT,
+    onderwijs_nummer TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_sensitive_created_at
+    ON secret_sensitive(created_at);
+
+CREATE TABLE IF NOT EXISTS secret_regular (
+    uuid TEXT PRIMARY KEY,
+    geslacht VARCHAR(8),
+    nationaliteit_1 VARCHAR(255),
+    nationaliteit_2 VARCHAR(255),
+    nationaliteit_3 VARCHAR(255),
+    geboorteland VARCHAR(255),
+    geboorteland_ouder_1 VARCHAR(255),
+    geboorteland_ouder_2 VARCHAR(255),
+    postcodecijfer_ho VARCHAR(8),
+    indicatie_eer_actueel VARCHAR(255),
+    indicatie_internationale_student VARCHAR(255),
+    nationaliteit_eer_actueel VARCHAR(255),
+    herkomstland_cbr VARCHAR(255),
+    herkomstindikking_cbr VARCHAR(255),
+    indicatie_geboren VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (uuid) REFERENCES secret_sensitive(uuid) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_secret_regular_created_at
+    ON secret_regular(created_at);

--- a/init.sql
+++ b/init.sql
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS secret_sensitive (
     persoonsgebonden_nummer TEXT,
     burgerservice_nummer TEXT,
     onderwijs_nummer TEXT,
+    -- Per-record PBKDF2 salt (base64) used to derive this row's encryption key.
+    salt TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ eencijferho = "eencijferho.cli:main"
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-cov>=6.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ Issues = "https://github.com/cedanl/1cijferho/issues"
 frontend = [
     "streamlit>=1.41.1",
     "streamlit-extras>=0.6.0",
+    "streamlit-js>=1.0.8",
+    "pandas>=2.0",
 ]
 dev = [
     "ruff>=0.10.0",
@@ -64,6 +66,11 @@ postgres = [
     "sqlalchemy>=2.0",
 ]
 all-backends = [
+    "eencijferho[minio]",
+    "eencijferho[postgres]",
+]
+demo = [
+    "eencijferho[frontend]",
     "eencijferho[minio]",
     "eencijferho[postgres]",
 ]

--- a/src/eencijferho/io/personal_data.py
+++ b/src/eencijferho/io/personal_data.py
@@ -14,7 +14,6 @@ HTTP, matching this repo's storage-abstraction architecture.
 
 from __future__ import annotations
 
-import json
 from datetime import datetime
 
 from eencijferho.io import get_backend
@@ -51,6 +50,7 @@ CREATE TABLE IF NOT EXISTS secret_sensitive (
     persoonsgebonden_nummer TEXT,
     burgerservice_nummer TEXT,
     onderwijs_nummer TEXT,
+    salt TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )
 """
@@ -100,7 +100,7 @@ def _table_columns(pg, table_name: str) -> list[str]:
         cur.execute(
             """
             SELECT column_name FROM information_schema.columns
-            WHERE table_name = %s AND column_name NOT IN ('uuid', 'created_at')
+            WHERE table_name = %s AND column_name NOT IN ('uuid', 'created_at', 'salt')
             ORDER BY ordinal_position
             """,
             (table_name,),
@@ -151,7 +151,7 @@ def upload_personal_data(rows: list[dict]) -> dict:
     pg = _pg()
     inserted = 0
     minio_rows: list[dict] = []
-    exclude = {c.lower() for c in sensitive_cols + regular_cols}
+    exclude = {c.lower() for c in sensitive_cols + regular_cols} | {"salt"}
 
     with pg.conn.cursor() as cur:
         for row in rows:
@@ -159,10 +159,12 @@ def upload_personal_data(rows: list[dict]) -> dict:
             if not uuid:
                 continue
 
-            # secret_sensitive
-            cols = ["uuid"] + sensitive_cols
-            vals = [uuid] + [_get_value(row, c) for c in sensitive_cols]
-            updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in sensitive_cols)
+            # secret_sensitive — salt is stored alongside the encrypted fields so
+            # the per-record key can be re-derived on decrypt.
+            sensitive_with_salt = sensitive_cols + ["salt"]
+            cols = ["uuid"] + sensitive_with_salt
+            vals = [uuid] + [_get_value(row, c) for c in sensitive_with_salt]
+            updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in sensitive_with_salt)
             cur.execute(
                 f"INSERT INTO secret_sensitive ({', '.join(cols)}) "
                 f"VALUES ({', '.join(['%s'] * len(cols))}) "
@@ -257,7 +259,7 @@ def view_file(filename: str, mode: str = "raw") -> list[dict]:
     pg = _pg()
     regular = _fetch_db_rows(pg, "secret_regular", regular_cols, uuids)
     sensitive = (
-        _fetch_db_rows(pg, "secret_sensitive", sensitive_cols, uuids)
+        _fetch_db_rows(pg, "secret_sensitive", sensitive_cols + ["salt"], uuids)
         if mode == "with_encrypted"
         else {}
     )

--- a/src/eencijferho/io/personal_data.py
+++ b/src/eencijferho/io/personal_data.py
@@ -290,19 +290,24 @@ def view_file(filename: str, mode: str = "raw") -> list[dict]:
         else {}
     )
 
-    merged = []
-    for file_row in file_data:
-        uuid = file_row.get("uuid")
-        ordered = {"uuid": uuid} if uuid is not None else {}
-        if mode == "with_encrypted" and uuid in sensitive:
-            ordered.update(sensitive[uuid])
-        if uuid in regular:
-            ordered.update(regular[uuid])
-        for key, value in file_row.items():
-            if key != "uuid":
-                ordered[key] = value
-        merged.append(ordered)
-    return merged
+    return [
+        _merge_row(file_row, regular, sensitive, mode == "with_encrypted")
+        for file_row in file_data
+    ]
+
+
+def _merge_row(file_row: dict, regular: dict, sensitive: dict, include_sensitive: bool) -> dict:
+    """Combine a MinIO row with its DB-side regular/sensitive fields, uuid first."""
+    uuid = file_row.get("uuid")
+    ordered = {"uuid": uuid} if uuid is not None else {}
+    if include_sensitive and uuid in sensitive:
+        ordered.update(sensitive[uuid])
+    if uuid in regular:
+        ordered.update(regular[uuid])
+    for key, value in file_row.items():
+        if key != "uuid":
+            ordered[key] = value
+    return ordered
 
 
 def delete_file(filename: str) -> dict:

--- a/src/eencijferho/io/personal_data.py
+++ b/src/eencijferho/io/personal_data.py
@@ -1,0 +1,300 @@
+"""In-process personal-data store for the Streamlit demo.
+
+Splits an uploaded record into three destinations using the storage backends
+in :mod:`eencijferho.io`:
+
+- ``secret_sensitive`` (PostgreSQL): UUID + encrypted personal identifiers
+- ``secret_regular``   (PostgreSQL): UUID + demographic fields
+- a JSON object in MinIO: UUID + remaining non-sensitive fields
+
+This is the library equivalent of the FastAPI ``personal-data`` router from the
+sibling 1cijfer-config repo, but it calls the backends directly instead of over
+HTTP, matching this repo's storage-abstraction architecture.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from eencijferho.io import get_backend
+
+MINIO_PREFIX = "personal-data"
+
+# Columns expected in the two PostgreSQL tables (excluding uuid/created_at).
+# These mirror init.sql; read_schema() refreshes them from the live DB.
+DEFAULT_SENSITIVE_COLUMNS = [
+    "persoonsgebonden_nummer",
+    "burgerservice_nummer",
+    "onderwijs_nummer",
+]
+DEFAULT_REGULAR_COLUMNS = [
+    "geslacht",
+    "nationaliteit_1",
+    "nationaliteit_2",
+    "nationaliteit_3",
+    "geboorteland",
+    "geboorteland_ouder_1",
+    "geboorteland_ouder_2",
+    "postcodecijfer_ho",
+    "indicatie_eer_actueel",
+    "indicatie_internationale_student",
+    "nationaliteit_eer_actueel",
+    "herkomstland_cbr",
+    "herkomstindikking_cbr",
+    "indicatie_geboren",
+]
+
+_SENSITIVE_DDL = """
+CREATE TABLE IF NOT EXISTS secret_sensitive (
+    uuid TEXT PRIMARY KEY,
+    persoonsgebonden_nummer TEXT,
+    burgerservice_nummer TEXT,
+    onderwijs_nummer TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+_REGULAR_DDL = """
+CREATE TABLE IF NOT EXISTS secret_regular (
+    uuid TEXT PRIMARY KEY,
+    geslacht VARCHAR(8),
+    nationaliteit_1 VARCHAR(255),
+    nationaliteit_2 VARCHAR(255),
+    nationaliteit_3 VARCHAR(255),
+    geboorteland VARCHAR(255),
+    geboorteland_ouder_1 VARCHAR(255),
+    geboorteland_ouder_2 VARCHAR(255),
+    postcodecijfer_ho VARCHAR(8),
+    indicatie_eer_actueel VARCHAR(255),
+    indicatie_internationale_student VARCHAR(255),
+    nationaliteit_eer_actueel VARCHAR(255),
+    herkomstland_cbr VARCHAR(255),
+    herkomstindikking_cbr VARCHAR(255),
+    indicatie_geboren VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (uuid) REFERENCES secret_sensitive(uuid) ON DELETE CASCADE
+)
+"""
+
+
+def _pg():
+    """Return the PostgresBackend (autocommit psycopg2 connection on .conn)."""
+    return get_backend("postgres")
+
+
+def _minio():
+    return get_backend("minio")
+
+
+def ensure_schema() -> None:
+    """Create the two personal-data tables if they do not exist."""
+    pg = _pg()
+    with pg.conn.cursor() as cur:
+        cur.execute(_SENSITIVE_DDL)
+        cur.execute(_REGULAR_DDL)
+
+
+def _table_columns(pg, table_name: str) -> list[str]:
+    with pg.conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = %s AND column_name NOT IN ('uuid', 'created_at')
+            ORDER BY ordinal_position
+            """,
+            (table_name,),
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
+def get_schema() -> dict[str, list[str]]:
+    """Return the sensitive/regular column names from the live database.
+
+    Falls back to the defaults if the tables don't exist yet.
+    """
+    try:
+        pg = _pg()
+        ensure_schema()
+        sensitive = _table_columns(pg, "secret_sensitive") or DEFAULT_SENSITIVE_COLUMNS
+        regular = _table_columns(pg, "secret_regular") or DEFAULT_REGULAR_COLUMNS
+        return {"sensitive_columns": sensitive, "regular_columns": regular}
+    except Exception:
+        return {
+            "sensitive_columns": DEFAULT_SENSITIVE_COLUMNS,
+            "regular_columns": DEFAULT_REGULAR_COLUMNS,
+        }
+
+
+def _get_value(row: dict, col: str):
+    """Case-insensitive lookup of a column in a row dict."""
+    if col in row:
+        return row[col]
+    lower = {k.lower(): k for k in row}
+    if col.lower() in lower:
+        return row[lower[col.lower()]]
+    return None
+
+
+def upload_personal_data(rows: list[dict]) -> dict:
+    """Store pre-encrypted rows across PostgreSQL tables and a MinIO JSON file.
+
+    Each row must already contain a ``uuid`` plus encrypted sensitive fields and
+    plaintext regular/extra fields (encryption happens client-side in the browser
+    via Pyodide before this is ever called).
+    """
+    ensure_schema()
+    schema = get_schema()
+    sensitive_cols = schema["sensitive_columns"]
+    regular_cols = schema["regular_columns"]
+
+    pg = _pg()
+    inserted = 0
+    minio_rows: list[dict] = []
+    exclude = {c.lower() for c in sensitive_cols + regular_cols}
+
+    with pg.conn.cursor() as cur:
+        for row in rows:
+            uuid = row.get("uuid")
+            if not uuid:
+                continue
+
+            # secret_sensitive
+            cols = ["uuid"] + sensitive_cols
+            vals = [uuid] + [_get_value(row, c) for c in sensitive_cols]
+            updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in sensitive_cols)
+            cur.execute(
+                f"INSERT INTO secret_sensitive ({', '.join(cols)}) "
+                f"VALUES ({', '.join(['%s'] * len(cols))}) "
+                f"ON CONFLICT (uuid) DO UPDATE SET {updates}",
+                vals,
+            )
+
+            # secret_regular
+            cols = ["uuid"] + regular_cols
+            vals = [uuid] + [_get_value(row, c) for c in regular_cols]
+            updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in regular_cols)
+            cur.execute(
+                f"INSERT INTO secret_regular ({', '.join(cols)}) "
+                f"VALUES ({', '.join(['%s'] * len(cols))}) "
+                f"ON CONFLICT (uuid) DO UPDATE SET {updates}",
+                vals,
+            )
+            inserted += 1
+
+            # MinIO: uuid + everything that isn't a known secret/regular column
+            minio_row = {"uuid": uuid}
+            for key, value in row.items():
+                if key != "uuid" and key.lower() not in exclude:
+                    minio_row[key] = value
+            minio_rows.append(minio_row)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    minio_filename = f"{MINIO_PREFIX}/personal_data_{timestamp}.json"
+    _minio().write_json(minio_rows, minio_filename)
+
+    return {"inserted": inserted, "minio_file": minio_filename}
+
+
+def list_minio_files() -> list[dict]:
+    """List the personal-data JSON objects stored in MinIO."""
+    minio = _minio()
+    keys = minio.list_files(f"{MINIO_PREFIX}/*.json")
+    files = []
+    for key in sorted(keys):
+        try:
+            stat = minio.client.stat_object(minio.bucket, key)
+            files.append(
+                {
+                    "name": key,
+                    "size": stat.size,
+                    "last_modified": stat.last_modified.isoformat()
+                    if stat.last_modified
+                    else None,
+                }
+            )
+        except Exception:
+            files.append({"name": key, "size": None, "last_modified": None})
+    return files
+
+
+def _fetch_db_rows(pg, table: str, columns: list[str], uuids: list[str]) -> dict[str, dict]:
+    if not uuids:
+        return {}
+    placeholders = ", ".join(["%s"] * len(uuids))
+    col_str = ", ".join(columns)
+    with pg.conn.cursor() as cur:
+        cur.execute(
+            f"SELECT uuid, {col_str} FROM {table} WHERE uuid IN ({placeholders})",
+            uuids,
+        )
+        result = {}
+        for db_row in cur.fetchall():
+            result[str(db_row[0])] = {col: db_row[i + 1] for i, col in enumerate(columns)}
+    return result
+
+
+def view_file(filename: str, mode: str = "raw") -> list[dict]:
+    """Return file contents at one of three resolution levels.
+
+    Modes:
+        raw            — MinIO file only (uuid + extra fields).
+        with_regular   — joined with secret_regular (demographic data).
+        with_encrypted — joined with secret_sensitive (still encrypted) + regular.
+    """
+    file_data = _minio().read_json(filename)
+    if not isinstance(file_data, list):
+        file_data = [file_data]
+
+    if mode == "raw":
+        return file_data
+
+    schema = get_schema()
+    regular_cols = schema["regular_columns"]
+    sensitive_cols = schema["sensitive_columns"]
+    uuids = [r["uuid"] for r in file_data if "uuid" in r]
+
+    pg = _pg()
+    regular = _fetch_db_rows(pg, "secret_regular", regular_cols, uuids)
+    sensitive = (
+        _fetch_db_rows(pg, "secret_sensitive", sensitive_cols, uuids)
+        if mode == "with_encrypted"
+        else {}
+    )
+
+    merged = []
+    for file_row in file_data:
+        uuid = file_row.get("uuid")
+        ordered = {"uuid": uuid} if uuid is not None else {}
+        if mode == "with_encrypted" and uuid in sensitive:
+            ordered.update(sensitive[uuid])
+        if uuid in regular:
+            ordered.update(regular[uuid])
+        for key, value in file_row.items():
+            if key != "uuid":
+                ordered[key] = value
+        merged.append(ordered)
+    return merged
+
+
+def delete_file(filename: str) -> dict:
+    """Delete a MinIO file and the DB records for the UUIDs it references."""
+    minio = _minio()
+    file_data = minio.read_json(filename)
+    if not isinstance(file_data, list):
+        file_data = [file_data]
+    uuids = [r["uuid"] for r in file_data if "uuid" in r]
+
+    deleted = 0
+    if uuids:
+        pg = _pg()
+        placeholders = ", ".join(["%s"] * len(uuids))
+        with pg.conn.cursor() as cur:
+            # secret_regular cascades from secret_sensitive via FK.
+            cur.execute(
+                f"DELETE FROM secret_sensitive WHERE uuid IN ({placeholders})", uuids
+            )
+            deleted = cur.rowcount
+
+    minio.delete(filename)
+    return {"deleted_records": deleted, "file": filename}

--- a/src/eencijferho/io/personal_data.py
+++ b/src/eencijferho/io/personal_data.py
@@ -14,11 +14,35 @@ HTTP, matching this repo's storage-abstraction architecture.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import os
 from datetime import datetime
 
 from eencijferho.io import get_backend
 
 MINIO_PREFIX = "personal-data"
+
+# HMAC key for server-side UUID derivation. Kept on the server so it never
+# reaches the browser; a client-side key would let anyone forge UUIDs for a
+# known PGN (the PGN search space is small).
+ENCRYPT_KEY_ENV = "EENCIJFERHO_ENCRYPT_KEY"
+DEMO_UUID_KEY = "eencijfer-demo-uuid-key-change-me"
+
+
+def is_demo_key() -> bool:
+    """True when no real key is configured and the demo fallback is in use."""
+    return not os.environ.get(ENCRYPT_KEY_ENV)
+
+
+def _uuid_key() -> bytes:
+    return os.environ.get(ENCRYPT_KEY_ENV, DEMO_UUID_KEY).encode("utf-8")
+
+
+def derive_uuid(source: str) -> str:
+    """Derive a stable UUID from a value via keyed HMAC-SHA256 (server-side)."""
+    h = hmac.new(_uuid_key(), str(source).encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
 
 # Columns expected in the two PostgreSQL tables (excluding uuid/created_at).
 # These mirror init.sql; read_schema() refreshes them from the live DB.
@@ -139,9 +163,10 @@ def _get_value(row: dict, col: str):
 def upload_personal_data(rows: list[dict]) -> dict:
     """Store pre-encrypted rows across PostgreSQL tables and a MinIO JSON file.
 
-    Each row must already contain a ``uuid`` plus encrypted sensitive fields and
-    plaintext regular/extra fields (encryption happens client-side in the browser
-    via Pyodide before this is ever called).
+    Each row carries encrypted sensitive fields, plaintext regular/extra fields,
+    and a ``__uuid_source`` value (the plaintext PGN) from which the UUID is
+    derived here via keyed HMAC. The source is used to compute the UUID and then
+    dropped — it is never stored.
     """
     ensure_schema()
     schema = get_schema()
@@ -151,13 +176,14 @@ def upload_personal_data(rows: list[dict]) -> dict:
     pg = _pg()
     inserted = 0
     minio_rows: list[dict] = []
-    exclude = {c.lower() for c in sensitive_cols + regular_cols} | {"salt"}
+    exclude = {c.lower() for c in sensitive_cols + regular_cols} | {"salt", "__uuid_source"}
 
     with pg.conn.cursor() as cur:
         for row in rows:
-            uuid = row.get("uuid")
-            if not uuid:
+            uuid_source = row.get("__uuid_source")
+            if not uuid_source:
                 continue
+            uuid = derive_uuid(uuid_source)
 
             # secret_sensitive — salt is stored alongside the encrypted fields so
             # the per-record key can be re-derived on decrypt.

--- a/src/frontend/Files/Browse_Personal_Data.py
+++ b/src/frontend/Files/Browse_Personal_Data.py
@@ -2,7 +2,7 @@ import base64
 import json
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import streamlit as st
 import streamlit.components.v1 as components
 
@@ -21,8 +21,9 @@ def _load_html(name: str, payload_b64: str) -> str:
 st.title("Persoonsgegevens bekijken")
 st.markdown("""
 <div class="page-intro">
-    Bekijk bestanden uit MinIO op drie detailniveaus. Ontsleuteling van gevoelige
-    velden gebeurt <strong>in uw browser</strong> — het wachtwoord verlaat uw browser nooit.
+    Bekijk bestanden uit MinIO op drie detailniveaus. Gevoelige velden zijn
+    versleuteld opgeslagen; ontsleuteling gebeurt <strong>in uw browser</strong> met
+    uw wachtwoord.
 </div>
 """, unsafe_allow_html=True)
 
@@ -87,10 +88,10 @@ st.subheader("Stap 3 · Data bekijken")
 if view_mode.startswith("1"):
     try:
         data = personal_data.view_file(selected_file, mode="raw")
-        df = pd.DataFrame(data)
+        df = pl.DataFrame(data, infer_schema_length=None)
         st.write(f"**{len(df)} records** (UUID + overige velden, geen gevoelige data)")
         st.dataframe(df, use_container_width=True)
-        st.download_button("Download als CSV", df.to_csv(index=False),
+        st.download_button("Download als CSV", df.write_csv(),
                            file_name="raw.csv", mime="text/csv")
     except Exception as e:
         st.error(f"Fout bij laden: {e}")
@@ -98,10 +99,10 @@ if view_mode.startswith("1"):
 elif view_mode.startswith("2"):
     try:
         data = personal_data.view_file(selected_file, mode="with_regular")
-        df = pd.DataFrame(data)
+        df = pl.DataFrame(data, infer_schema_length=None)
         st.write(f"**{len(df)} records** (samengevoegd met demografische data uit secret_regular)")
         st.dataframe(df, use_container_width=True)
-        st.download_button("Download als CSV", df.to_csv(index=False),
+        st.download_button("Download als CSV", df.write_csv(),
                            file_name="with_regular.csv", mime="text/csv")
     except Exception as e:
         st.error(f"Fout bij laden: {e}")
@@ -117,7 +118,7 @@ else:
         st.info("Voer het ontsleutelwachtwoord in.")
         st.stop()
 
-    st.warning("Ontsleuteling gebeurt in uw browser. Het wachtwoord wordt nooit naar de server gestuurd.")
+    st.info("Ontsleuteling gebeurt in uw browser met Pyodide; de opgeslagen data blijft versleuteld in de database.")
 
     try:
         sensitive_fields = personal_data.get_schema()["sensitive_columns"]
@@ -146,5 +147,5 @@ with st.expander("Over de weergavemodi"):
     **2. Met reguliere data** — join met `secret_regular` op UUID (demografische velden).
 
     **3. Met ontsleutelde data** — join met `secret_sensitive` (versleuteld), daarna
-    client-side ontsleuteld met Pyodide. Het wachtwoord verlaat uw browser nooit.
+    client-side ontsleuteld met Pyodide in uw browser.
     """)

--- a/src/frontend/Files/Browse_Personal_Data.py
+++ b/src/frontend/Files/Browse_Personal_Data.py
@@ -1,0 +1,250 @@
+import base64
+import json
+
+import pandas as pd
+import streamlit as st
+import streamlit.components.v1 as components
+
+from eencijferho.io import personal_data
+
+# -----------------------------------------------------------------------------
+# Page Header
+# -----------------------------------------------------------------------------
+st.title("Persoonsgegevens bekijken")
+st.markdown("""
+<div class="page-intro">
+    Bekijk bestanden uit MinIO op drie detailniveaus. Ontsleuteling van gevoelige
+    velden gebeurt <strong>in uw browser</strong> — het wachtwoord verlaat uw browser nooit.
+</div>
+""", unsafe_allow_html=True)
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 1 — Select file
+# -----------------------------------------------------------------------------
+st.subheader("Stap 1 · Bestand kiezen")
+
+try:
+    files = personal_data.list_minio_files()
+except Exception as e:
+    st.error(f"Verbindingsfout met MinIO: {e}")
+    st.info("Controleer of de MinIO-container draait (`docker compose up`).")
+    st.stop()
+
+if not files:
+    st.info("Geen bestanden gevonden in MinIO. Upload eerst data via 'Persoonsgegevens uploaden'.")
+    st.stop()
+
+labels = [f"{f['name']} ({f['size']} bytes, {f['last_modified']})" for f in files]
+idx = st.selectbox("Kies een bestand", range(len(files)), format_func=lambda i: labels[i])
+selected_file = files[idx]["name"]
+
+col1, col2 = st.columns([3, 1])
+with col1:
+    st.success(f"Geselecteerd: **{selected_file}**")
+with col2:
+    if st.button("Bestand verwijderen", type="secondary",
+                 help="Verwijdert dit bestand én de bijbehorende databaserecords"):
+        try:
+            result = personal_data.delete_file(selected_file)
+            st.success(f"Verwijderd: {result['deleted_records']} databaserecords + bestand.")
+            st.info("Ververs de pagina om de bijgewerkte lijst te zien.")
+            st.stop()
+        except Exception as e:
+            st.error(f"Fout bij verwijderen: {e}")
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 2 — Select viewing mode
+# -----------------------------------------------------------------------------
+st.subheader("Stap 2 · Weergavemodus kiezen")
+
+view_mode = st.radio(
+    "Hoe wilt u dit bestand bekijken?",
+    [
+        "1. Ruwe inhoud (alleen UUID + overige velden)",
+        "2. Met reguliere data (join met secret_regular)",
+        "3. Met ontsleutelde data (wachtwoord vereist)",
+    ],
+)
+
+st.markdown("---")
+st.subheader("Stap 3 · Data bekijken")
+
+# -----------------------------------------------------------------------------
+# Mode 1 & 2 — server-side joins, rendered directly
+# -----------------------------------------------------------------------------
+if view_mode.startswith("1"):
+    try:
+        data = personal_data.view_file(selected_file, mode="raw")
+        df = pd.DataFrame(data)
+        st.write(f"**{len(df)} records** (UUID + overige velden, geen gevoelige data)")
+        st.dataframe(df, use_container_width=True)
+        st.download_button("Download als CSV", df.to_csv(index=False),
+                           file_name="raw.csv", mime="text/csv")
+    except Exception as e:
+        st.error(f"Fout bij laden: {e}")
+
+elif view_mode.startswith("2"):
+    try:
+        data = personal_data.view_file(selected_file, mode="with_regular")
+        df = pd.DataFrame(data)
+        st.write(f"**{len(df)} records** (samengevoegd met demografische data uit secret_regular)")
+        st.dataframe(df, use_container_width=True)
+        st.download_button("Download als CSV", df.to_csv(index=False),
+                           file_name="with_regular.csv", mime="text/csv")
+    except Exception as e:
+        st.error(f"Fout bij laden: {e}")
+
+# -----------------------------------------------------------------------------
+# Mode 3 — client-side decryption with Pyodide
+# -----------------------------------------------------------------------------
+else:
+    st.write("Dit ontsleutelt gevoelige identifiers (Persoonsgebonden_nummer, Burgerservice_nummer, Onderwijs_nummer).")
+    password = st.text_input("Voer het ontsleutelwachtwoord in", type="password",
+                             help="Het wachtwoord dat bij versleuteling is gebruikt.")
+    if not password:
+        st.info("Voer het ontsleutelwachtwoord in.")
+        st.stop()
+
+    st.warning("Ontsleuteling gebeurt in uw browser. Het wachtwoord wordt nooit naar de server gestuurd.")
+
+    try:
+        sensitive_fields = personal_data.get_schema()["sensitive_columns"]
+        data = personal_data.view_file(selected_file, mode="with_encrypted")
+    except Exception as e:
+        st.error(f"Fout bij laden: {e}")
+        st.stop()
+
+    data_base64 = base64.b64encode(json.dumps(data).encode()).decode()
+    password_escaped = password.replace("'", "\\'").replace('"', '\\"')
+    sensitive_fields_json = json.dumps(sensitive_fields)
+
+    decryption_html = f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+    <style>
+        body {{ font-family: 'Source Sans Pro', sans-serif; padding: 20px; }}
+        .status {{ padding: 15px; margin: 10px 0; border-radius: 5px; font-size: 14px; }}
+        .loading {{ background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; }}
+        .success {{ background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }}
+        .error {{ background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }}
+        table {{ width: 100%; border-collapse: collapse; font-size: 12px; }}
+        th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
+        th {{ background-color: #f2f2f2; font-weight: bold; }}
+        tr:nth-child(even) {{ background-color: #f9f9f9; }}
+        #preview {{ max-height: 420px; overflow: auto; margin-top: 10px; }}
+    </style>
+</head>
+<body>
+    <div id="status" class="status loading">Pyodide initialiseren...</div>
+    <div id="preview"></div>
+
+    <script type="text/javascript">
+        let pyodide;
+
+        async function initPyodide() {{
+            try {{
+                document.getElementById('status').innerHTML = 'Pyodide laden (10-20 seconden)...';
+                pyodide = await loadPyodide();
+                document.getElementById('status').innerHTML = 'cryptography installeren...';
+                await pyodide.loadPackage(['micropip']);
+                await pyodide.runPythonAsync(`
+                    import micropip
+                    await micropip.install('cryptography')
+                `);
+                decryptData();
+            }} catch (error) {{
+                document.getElementById('status').innerHTML = 'Fout bij laden Pyodide: ' + error;
+                document.getElementById('status').className = 'status error';
+                console.error(error);
+            }}
+        }}
+
+        async function decryptData() {{
+            try {{
+                document.getElementById('status').innerHTML = 'Data ontsleutelen in browser...';
+                document.getElementById('status').className = 'status loading';
+
+                pyodide.globals.set('data_input', atob('{data_base64}'));
+                pyodide.globals.set('password_input', `{password_escaped}`);
+                pyodide.globals.set('sensitive_fields_input', {sensitive_fields_json});
+
+                const result = await pyodide.runPythonAsync(`
+import json, base64
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt=b'eencijfer_salt_2025'):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+cipher = Fernet(derive_key(password_input))
+data = json.loads(data_input)
+sensitive_fields = sensitive_fields_input
+decrypted_count = 0
+for row in data:
+    for field in sensitive_fields:
+        if field in row and row[field]:
+            try:
+                row[field] = cipher.decrypt(row[field].encode()).decode()
+                decrypted_count += 1
+            except Exception as e:
+                row[field] = "DECRYPT_ERROR"
+str(decrypted_count) + "||" + json.dumps(data)
+                `);
+
+                const parts = result.split('||', 2);
+                const decrypted = JSON.parse(parts[1]);
+                let html = '<strong>Ontsleuteld: ' + parts[0] + ' waarden.</strong><br><br>';
+                if (decrypted.length > 0) {{
+                    html += '<table><thead><tr>';
+                    for (let key in decrypted[0]) html += '<th>' + key + '</th>';
+                    html += '</tr></thead><tbody>';
+                    for (let i = 0; i < Math.min(decrypted.length, 20); i++) {{
+                        html += '<tr>';
+                        for (let key in decrypted[i]) html += '<td>' + (decrypted[i][key] ?? '') + '</td>';
+                        html += '</tr>';
+                    }}
+                    html += '</tbody></table>';
+                    if (decrypted.length > 20)
+                        html += '<br><em>Eerste 20 van ' + decrypted.length + ' records.</em>';
+                }}
+                document.getElementById('preview').innerHTML = html;
+                document.getElementById('status').innerHTML = 'Klaar! ' + parts[0] + ' waarden ontsleuteld.';
+                document.getElementById('status').className = 'status success';
+            }} catch (error) {{
+                document.getElementById('status').innerHTML =
+                    'Ontsleutelfout: ' + error + ' — controleer het wachtwoord.';
+                document.getElementById('status').className = 'status error';
+                console.error(error);
+            }}
+        }}
+
+        initPyodide();
+    </script>
+</body>
+</html>
+"""
+    components.html(decryption_html, height=600, scrolling=True)
+
+# -----------------------------------------------------------------------------
+# Info
+# -----------------------------------------------------------------------------
+st.markdown("---")
+with st.expander("Over de weergavemodi"):
+    st.markdown("""
+    **1. Ruwe inhoud** — precies wat in het MinIO-bestand staat (UUID + overige velden).
+
+    **2. Met reguliere data** — join met `secret_regular` op UUID (demografische velden).
+
+    **3. Met ontsleutelde data** — join met `secret_sensitive` (versleuteld), daarna
+    client-side ontsleuteld met Pyodide. Het wachtwoord verlaat uw browser nooit.
+    """)

--- a/src/frontend/Files/Browse_Personal_Data.py
+++ b/src/frontend/Files/Browse_Personal_Data.py
@@ -1,11 +1,19 @@
 import base64
 import json
+from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 import streamlit.components.v1 as components
 
 from eencijferho.io import personal_data
+
+_JS_DIR = Path(__file__).parent / "js"
+
+
+def _load_html(name: str, payload_b64: str) -> str:
+    template = (_JS_DIR / name).read_text(encoding="utf-8")
+    return template.replace("__PAYLOAD_B64__", payload_b64)
 
 # -----------------------------------------------------------------------------
 # Page Header
@@ -118,121 +126,13 @@ else:
         st.error(f"Fout bij laden: {e}")
         st.stop()
 
-    data_base64 = base64.b64encode(json.dumps(data).encode()).decode()
-    password_escaped = password.replace("'", "\\'").replace('"', '\\"')
-    sensitive_fields_json = json.dumps(sensitive_fields)
-
-    decryption_html = f"""
-<!DOCTYPE html>
-<html>
-<head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
-    <style>
-        body {{ font-family: 'Source Sans Pro', sans-serif; padding: 20px; }}
-        .status {{ padding: 15px; margin: 10px 0; border-radius: 5px; font-size: 14px; }}
-        .loading {{ background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; }}
-        .success {{ background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }}
-        .error {{ background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }}
-        table {{ width: 100%; border-collapse: collapse; font-size: 12px; }}
-        th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
-        th {{ background-color: #f2f2f2; font-weight: bold; }}
-        tr:nth-child(even) {{ background-color: #f9f9f9; }}
-        #preview {{ max-height: 420px; overflow: auto; margin-top: 10px; }}
-    </style>
-</head>
-<body>
-    <div id="status" class="status loading">Pyodide initialiseren...</div>
-    <div id="preview"></div>
-
-    <script type="text/javascript">
-        let pyodide;
-
-        async function initPyodide() {{
-            try {{
-                document.getElementById('status').innerHTML = 'Pyodide laden (10-20 seconden)...';
-                pyodide = await loadPyodide();
-                document.getElementById('status').innerHTML = 'cryptography installeren...';
-                await pyodide.loadPackage(['micropip']);
-                await pyodide.runPythonAsync(`
-                    import micropip
-                    await micropip.install('cryptography')
-                `);
-                decryptData();
-            }} catch (error) {{
-                document.getElementById('status').innerHTML = 'Fout bij laden Pyodide: ' + error;
-                document.getElementById('status').className = 'status error';
-                console.error(error);
-            }}
-        }}
-
-        async function decryptData() {{
-            try {{
-                document.getElementById('status').innerHTML = 'Data ontsleutelen in browser...';
-                document.getElementById('status').className = 'status loading';
-
-                pyodide.globals.set('data_input', atob('{data_base64}'));
-                pyodide.globals.set('password_input', `{password_escaped}`);
-                pyodide.globals.set('sensitive_fields_input', {sensitive_fields_json});
-
-                const result = await pyodide.runPythonAsync(`
-import json, base64
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.backends import default_backend
-
-def derive_key(password, salt=b'eencijfer_salt_2025'):
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
-                     iterations=100000, backend=default_backend())
-    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
-
-cipher = Fernet(derive_key(password_input))
-data = json.loads(data_input)
-sensitive_fields = sensitive_fields_input
-decrypted_count = 0
-for row in data:
-    for field in sensitive_fields:
-        if field in row and row[field]:
-            try:
-                row[field] = cipher.decrypt(row[field].encode()).decode()
-                decrypted_count += 1
-            except Exception as e:
-                row[field] = "DECRYPT_ERROR"
-str(decrypted_count) + "||" + json.dumps(data)
-                `);
-
-                const parts = result.split('||', 2);
-                const decrypted = JSON.parse(parts[1]);
-                let html = '<strong>Ontsleuteld: ' + parts[0] + ' waarden.</strong><br><br>';
-                if (decrypted.length > 0) {{
-                    html += '<table><thead><tr>';
-                    for (let key in decrypted[0]) html += '<th>' + key + '</th>';
-                    html += '</tr></thead><tbody>';
-                    for (let i = 0; i < Math.min(decrypted.length, 20); i++) {{
-                        html += '<tr>';
-                        for (let key in decrypted[i]) html += '<td>' + (decrypted[i][key] ?? '') + '</td>';
-                        html += '</tr>';
-                    }}
-                    html += '</tbody></table>';
-                    if (decrypted.length > 20)
-                        html += '<br><em>Eerste 20 van ' + decrypted.length + ' records.</em>';
-                }}
-                document.getElementById('preview').innerHTML = html;
-                document.getElementById('status').innerHTML = 'Klaar! ' + parts[0] + ' waarden ontsleuteld.';
-                document.getElementById('status').className = 'status success';
-            }} catch (error) {{
-                document.getElementById('status').innerHTML =
-                    'Ontsleutelfout: ' + error + ' — controleer het wachtwoord.';
-                document.getElementById('status').className = 'status error';
-                console.error(error);
-            }}
-        }}
-
-        initPyodide();
-    </script>
-</body>
-</html>
-"""
+    payload = json.dumps({
+        "data_b64": base64.b64encode(json.dumps(data).encode()).decode(),
+        "password": password,
+        "sensitive_fields": sensitive_fields,
+    })
+    payload_b64 = base64.b64encode(payload.encode()).decode()
+    decryption_html = _load_html("decrypt_personal.html", payload_b64)
     components.html(decryption_html, height=600, scrolling=True)
 
 # -----------------------------------------------------------------------------

--- a/src/frontend/Files/Encrypt_Upload.py
+++ b/src/frontend/Files/Encrypt_Upload.py
@@ -1,0 +1,206 @@
+import base64
+import json
+from datetime import datetime
+
+import pandas as pd
+import streamlit as st
+from streamlit_js import st_js_blocking
+
+from eencijferho.io import get_backend
+
+# -----------------------------------------------------------------------------
+# Page Header
+# -----------------------------------------------------------------------------
+st.title("Versleutelen & uploaden")
+st.markdown("""
+<div class="page-intro">
+    Upload een CSV-bestand en versleutel een gevoelige kolom (zoals BSN) <strong>in uw
+    browser</strong>. Met één knop wordt de data versleuteld én opgeslagen in MinIO en
+    PostgreSQL. Onversleutelde data verlaat uw browser nooit.
+</div>
+""", unsafe_allow_html=True)
+
+st.markdown("""
+**Stappen:**
+1. Upload een CSV-bestand
+2. Kies de kolom die versleuteld moet worden
+3. Voer een wachtwoord in
+4. Klik op **Versleutelen & opslaan** — versleuteling gebeurt in uw browser,
+   daarna wordt het resultaat opgeslagen (downloaden blijft optioneel)
+""")
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 1 — Upload CSV
+# -----------------------------------------------------------------------------
+st.subheader("Stap 1 · CSV-bestand uploaden")
+
+uploaded_file = st.file_uploader("Kies een CSV-bestand", type=["csv"])
+
+if uploaded_file is None:
+    st.info("Upload een CSV-bestand om te beginnen.")
+    st.stop()
+
+try:
+    df = pd.read_csv(uploaded_file)
+except Exception as e:
+    st.error(f"Fout bij lezen van CSV: {e}")
+    st.stop()
+
+st.success(f"Bestand geladen: {uploaded_file.name}")
+st.write(f"**Rijen:** {len(df)} · **Kolommen:** {len(df.columns)}")
+with st.expander("Data bekijken"):
+    st.dataframe(df.head(10))
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 2 — Select column
+# -----------------------------------------------------------------------------
+st.subheader("Stap 2 · Kolom kiezen om te versleutelen")
+
+column_to_encrypt = st.selectbox(
+    "Selecteer de kolom met gevoelige data (bijv. BSN)",
+    options=df.columns.tolist(),
+    index=0,
+)
+with st.expander(f"Voorbeeldwaarden van '{column_to_encrypt}'"):
+    st.write(df[column_to_encrypt].head(10))
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 3 — Encrypt in browser + store, with one button
+# -----------------------------------------------------------------------------
+st.subheader("Stap 3 · Versleutelen & opslaan")
+
+password = st.text_input(
+    "Voer een versleutelwachtwoord in",
+    type="password",
+    help="Dit wachtwoord versleutelt de gekozen kolom in uw browser.",
+)
+
+if not password:
+    st.info("Voer een wachtwoord in om versleuteling in te schakelen.")
+    st.stop()
+
+st.warning("Onthoud dit wachtwoord — u heeft het nodig om de data later te ontsleutelen.")
+
+st.caption(
+    "De eerste keer duurt het laden van Pyodide in uw browser 10-20 seconden. "
+    "De versleuteling zelf gebeurt volledig lokaal."
+)
+
+
+def _build_encrypt_js(csv_b64: str, password: str, column: str) -> str:
+    """JS that loads Pyodide, encrypts the chosen column in-browser, returns the CSV."""
+    payload = json.dumps({"csv_b64": csv_b64, "password": password, "column": column})
+    payload_b64 = base64.b64encode(payload.encode()).decode()
+    return f"""
+const payload = JSON.parse(atob("{payload_b64}"));
+if (!window.__pyodidePromise) {{
+    window.__pyodidePromise = (async () => {{
+        const {{ loadPyodide }} = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`
+            import micropip
+            await micropip.install('cryptography')
+        `);
+        return py;
+    }})();
+}}
+const py = await window.__pyodidePromise;
+py.globals.set("csv_data_input", atob(payload.csv_b64));
+py.globals.set("password_input", payload.password);
+py.globals.set("column_name_input", payload.column);
+const result = await py.runPythonAsync(`
+import io, csv, base64
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt=b'eencijfer_salt_2025'):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+cipher = Fernet(derive_key(password_input))
+rows = list(csv.DictReader(io.StringIO(csv_data_input)))
+encrypted_count = 0
+for row in rows:
+    if column_name_input in row and row[column_name_input]:
+        row[column_name_input] = cipher.encrypt(row[column_name_input].encode()).decode()
+        encrypted_count += 1
+output = io.StringIO()
+if rows:
+    writer = csv.DictWriter(output, fieldnames=rows[0].keys())
+    writer.writeheader()
+    writer.writerows(rows)
+import json as _json
+_json.dumps({{"encrypted_count": encrypted_count, "csv": output.getvalue()}})
+`);
+return result;
+"""
+
+
+if st.button("Versleutelen & opslaan", type="primary"):
+    csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
+    js = _build_encrypt_js(csv_base64, password, column_to_encrypt)
+
+    with st.spinner("Versleutelen in uw browser (Pyodide)..."):
+        raw = st_js_blocking(js, key="encrypt_upload_js")
+
+    try:
+        result = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        st.error("Versleuteling in de browser is mislukt of niet voltooid. Probeer opnieuw.")
+        st.stop()
+
+    encrypted_csv = result["csv"]
+    encrypted_count = result["encrypted_count"]
+    encrypted_bytes = encrypted_csv.encode()
+
+    st.success(f"{encrypted_count} waarden versleuteld in kolom '{column_to_encrypt}'.")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    object_path = f"encrypted-uploads/{timestamp}_{uploaded_file.name}"
+
+    try:
+        with st.spinner("Opslaan in MinIO..."):
+            minio_uri = get_backend("minio").write_bytes(encrypted_bytes, object_path)
+        with st.spinner("Opslaan in PostgreSQL..."):
+            pg_uri = get_backend("postgres").write_bytes(encrypted_bytes, object_path)
+    except Exception as e:
+        st.error(f"Fout bij opslaan: {e}")
+        st.info("Controleer of de MinIO- en PostgreSQL-containers draaien (`docker compose up`).")
+        st.stop()
+
+    st.success("Versleuteld bestand opgeslagen in MinIO én PostgreSQL.")
+    st.json({"minio": minio_uri, "postgres": pg_uri, "bytes": len(encrypted_bytes)})
+
+    st.download_button(
+        "Versleuteld CSV downloaden (optioneel)",
+        data=encrypted_bytes,
+        file_name=f"encrypted_{uploaded_file.name}",
+        mime="text/csv",
+    )
+    st.balloons()
+
+# -----------------------------------------------------------------------------
+# Info
+# -----------------------------------------------------------------------------
+st.markdown("---")
+with st.expander("Hoe werkt browser-versleuteling?"):
+    st.markdown("""
+    **Pyodide** draait Python in uw browser via WebAssembly. Alle versleuteling
+    gebeurt **lokaal**; onversleutelde gevoelige data verlaat uw browser nooit.
+
+    1. CSV wordt in uw browser geladen
+    2. Het wachtwoord leidt een sleutel af (PBKDF2, 100.000 iteraties)
+    3. De gekozen kolom wordt versleuteld met Fernet (AES-128-CBC)
+    4. Alleen het **versleutelde** resultaat gaat naar de server
+    5. Het wordt opgeslagen in MinIO én PostgreSQL — downloaden is optioneel
+    """)

--- a/src/frontend/Files/Encrypt_Upload.py
+++ b/src/frontend/Files/Encrypt_Upload.py
@@ -14,7 +14,10 @@ _JS_DIR = Path(__file__).parent / "js"
 
 def _load_js(name: str, payload_b64: str) -> str:
     template = (_JS_DIR / name).read_text(encoding="utf-8")
-    return template.replace("__PAYLOAD_B64__", payload_b64)
+    bootstrap = (_JS_DIR / "_pyodide_bootstrap.js").read_text(encoding="utf-8")
+    return template.replace("__PYODIDE_BOOTSTRAP__", bootstrap).replace(
+        "__PAYLOAD_B64__", payload_b64
+    )
 
 # -----------------------------------------------------------------------------
 # Page Header

--- a/src/frontend/Files/Encrypt_Upload.py
+++ b/src/frontend/Files/Encrypt_Upload.py
@@ -15,7 +15,7 @@ _JS_DIR = Path(__file__).parent / "js"
 def _load_js(name: str, payload_b64: str) -> str:
     template = (_JS_DIR / name).read_text(encoding="utf-8")
     bootstrap = (_JS_DIR / "_pyodide_bootstrap.js").read_text(encoding="utf-8")
-    return template.replace("__PYODIDE_BOOTSTRAP__", bootstrap).replace(
+    return template.replace("// __PYODIDE_BOOTSTRAP__", bootstrap).replace(
         "__PAYLOAD_B64__", payload_b64
     )
 

--- a/src/frontend/Files/Encrypt_Upload.py
+++ b/src/frontend/Files/Encrypt_Upload.py
@@ -1,12 +1,20 @@
 import base64
 import json
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 from streamlit_js import st_js_blocking
 
 from eencijferho.io import get_backend
+
+_JS_DIR = Path(__file__).parent / "js"
+
+
+def _load_js(name: str, payload_b64: str) -> str:
+    template = (_JS_DIR / name).read_text(encoding="utf-8")
+    return template.replace("__PAYLOAD_B64__", payload_b64)
 
 # -----------------------------------------------------------------------------
 # Page Header
@@ -94,64 +102,27 @@ st.caption(
 
 
 def _build_encrypt_js(csv_b64: str, password: str, column: str) -> str:
-    """JS that loads Pyodide, encrypts the chosen column in-browser, returns the CSV."""
+    """Load the encrypt JS and inject all inputs as a single base64 JSON blob."""
     payload = json.dumps({"csv_b64": csv_b64, "password": password, "column": column})
     payload_b64 = base64.b64encode(payload.encode()).decode()
-    return f"""
-const payload = JSON.parse(atob("{payload_b64}"));
-if (!window.__pyodidePromise) {{
-    window.__pyodidePromise = (async () => {{
-        const {{ loadPyodide }} = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
-        const py = await loadPyodide();
-        await py.loadPackage(["micropip"]);
-        await py.runPythonAsync(`
-            import micropip
-            await micropip.install('cryptography')
-        `);
-        return py;
-    }})();
-}}
-const py = await window.__pyodidePromise;
-py.globals.set("csv_data_input", atob(payload.csv_b64));
-py.globals.set("password_input", payload.password);
-py.globals.set("column_name_input", payload.column);
-const result = await py.runPythonAsync(`
-import io, csv, base64
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.backends import default_backend
-
-def derive_key(password, salt=b'eencijfer_salt_2025'):
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
-                     iterations=100000, backend=default_backend())
-    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
-
-cipher = Fernet(derive_key(password_input))
-rows = list(csv.DictReader(io.StringIO(csv_data_input)))
-encrypted_count = 0
-for row in rows:
-    if column_name_input in row and row[column_name_input]:
-        row[column_name_input] = cipher.encrypt(row[column_name_input].encode()).decode()
-        encrypted_count += 1
-output = io.StringIO()
-if rows:
-    writer = csv.DictWriter(output, fieldnames=rows[0].keys())
-    writer.writeheader()
-    writer.writerows(rows)
-import json as _json
-_json.dumps({{"encrypted_count": encrypted_count, "csv": output.getvalue()}})
-`);
-return result;
-"""
+    return _load_js("encrypt_upload.js", payload_b64)
 
 
+# st_js_blocking calls st.stop() until the browser component returns a result on
+# a later rerun, so the click must be latched in session_state — gating the work
+# directly on st.button() would drop the async result on the next rerun.
 if st.button("Versleutelen & opslaan", type="primary"):
+    st.session_state["encrypt_upload_running"] = True
+
+if st.session_state.get("encrypt_upload_running"):
     csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
     js = _build_encrypt_js(csv_base64, password, column_to_encrypt)
 
     with st.spinner("Versleutelen in uw browser (Pyodide)..."):
         raw = st_js_blocking(js, key="encrypt_upload_js")
+
+    # Result is in; clear the latch so a rerun doesn't reprocess.
+    st.session_state["encrypt_upload_running"] = False
 
     try:
         result = json.loads(raw)
@@ -199,8 +170,10 @@ with st.expander("Hoe werkt browser-versleuteling?"):
     gebeurt **lokaal**; onversleutelde gevoelige data verlaat uw browser nooit.
 
     1. CSV wordt in uw browser geladen
-    2. Het wachtwoord leidt een sleutel af (PBKDF2, 100.000 iteraties)
-    3. De gekozen kolom wordt versleuteld met Fernet (AES-128-CBC)
+    2. Per rij wordt een willekeurige salt gegenereerd; het wachtwoord leidt
+       daarmee een sleutel af (PBKDF2, 100.000 iteraties)
+    3. De gekozen kolom wordt versleuteld met Fernet (AES-128-CBC); de salt komt
+       in een extra `salt`-kolom zodat ontsleuteling later mogelijk blijft
     4. Alleen het **versleutelde** resultaat gaat naar de server
     5. Het wordt opgeslagen in MinIO én PostgreSQL — downloaden is optioneel
     """)

--- a/src/frontend/Files/Encrypt_Upload.py
+++ b/src/frontend/Files/Encrypt_Upload.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import streamlit as st
 from streamlit_js import st_js_blocking
 
@@ -24,7 +24,7 @@ st.markdown("""
 <div class="page-intro">
     Upload een CSV-bestand en versleutel een gevoelige kolom (zoals BSN) <strong>in uw
     browser</strong>. Met één knop wordt de data versleuteld én opgeslagen in MinIO en
-    PostgreSQL. Onversleutelde data verlaat uw browser nooit.
+    PostgreSQL. De opgeslagen data bevat de gekozen kolom alleen in versleutelde vorm.
 </div>
 """, unsafe_allow_html=True)
 
@@ -51,7 +51,7 @@ if uploaded_file is None:
     st.stop()
 
 try:
-    df = pd.read_csv(uploaded_file)
+    df = pl.read_csv(uploaded_file, infer_schema_length=0)
 except Exception as e:
     st.error(f"Fout bij lezen van CSV: {e}")
     st.stop()
@@ -70,7 +70,7 @@ st.subheader("Stap 2 · Kolom kiezen om te versleutelen")
 
 column_to_encrypt = st.selectbox(
     "Selecteer de kolom met gevoelige data (bijv. BSN)",
-    options=df.columns.tolist(),
+    options=df.columns,
     index=0,
 )
 with st.expander(f"Voorbeeldwaarden van '{column_to_encrypt}'"):
@@ -115,7 +115,7 @@ if st.button("Versleutelen & opslaan", type="primary"):
     st.session_state["encrypt_upload_running"] = True
 
 if st.session_state.get("encrypt_upload_running"):
-    csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
+    csv_base64 = base64.b64encode(df.write_csv().encode()).decode()
     js = _build_encrypt_js(csv_base64, password, column_to_encrypt)
 
     with st.spinner("Versleutelen in uw browser (Pyodide)..."):
@@ -166,8 +166,9 @@ if st.session_state.get("encrypt_upload_running"):
 st.markdown("---")
 with st.expander("Hoe werkt browser-versleuteling?"):
     st.markdown("""
-    **Pyodide** draait Python in uw browser via WebAssembly. Alle versleuteling
-    gebeurt **lokaal**; onversleutelde gevoelige data verlaat uw browser nooit.
+    **Pyodide** draait Python in uw browser via WebAssembly. De versleuteling van de
+    gekozen kolom gebeurt **lokaal**, zodat de opgeslagen data die kolom alleen in
+    versleutelde vorm bevat.
 
     1. CSV wordt in uw browser geladen
     2. Per rij wordt een willekeurige salt gegenereerd; het wachtwoord leidt

--- a/src/frontend/Files/Upload_Personal_Data.py
+++ b/src/frontend/Files/Upload_Personal_Data.py
@@ -13,7 +13,10 @@ _JS_DIR = Path(__file__).parent / "js"
 
 def _load_js(name: str, payload_b64: str) -> str:
     template = (_JS_DIR / name).read_text(encoding="utf-8")
-    return template.replace("__PAYLOAD_B64__", payload_b64)
+    bootstrap = (_JS_DIR / "_pyodide_bootstrap.js").read_text(encoding="utf-8")
+    return template.replace("__PYODIDE_BOOTSTRAP__", bootstrap).replace(
+        "__PAYLOAD_B64__", payload_b64
+    )
 
 # -----------------------------------------------------------------------------
 # Schema (column names) from the database, with defaults as fallback

--- a/src/frontend/Files/Upload_Personal_Data.py
+++ b/src/frontend/Files/Upload_Personal_Data.py
@@ -1,11 +1,23 @@
 import base64
 import json
+import os
+from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 from streamlit_js import st_js_blocking
 
 from eencijferho.io import personal_data
+
+_JS_DIR = Path(__file__).parent / "js"
+# Key for HMAC-SHA256 UUID derivation; reused from the pseudonymizer config.
+_DEMO_UUID_KEY = "eencijfer-demo-uuid-key-change-me"
+_UUID_KEY = os.getenv("EENCIJFERHO_ENCRYPT_KEY", _DEMO_UUID_KEY)
+
+
+def _load_js(name: str, payload_b64: str) -> str:
+    template = (_JS_DIR / name).read_text(encoding="utf-8")
+    return template.replace("__PAYLOAD_B64__", payload_b64)
 
 # -----------------------------------------------------------------------------
 # Schema (column names) from the database, with defaults as fallback
@@ -124,89 +136,33 @@ st.caption(
 
 def _build_process_js(csv_b64: str, password: str,
                       sensitive: list[str], regular: list[str]) -> str:
-    """JS that loads Pyodide, encrypts sensitive cols + derives UUID, returns rows JSON."""
+    """Load the upload JS and inject all inputs as a single base64 JSON blob."""
     payload = json.dumps({
         "csv_b64": csv_b64,
         "password": password,
+        "uuid_key": _UUID_KEY,
         "sensitive": sensitive,
         "regular": regular,
     })
     payload_b64 = base64.b64encode(payload.encode()).decode()
-    return f"""
-const payload = JSON.parse(atob("{payload_b64}"));
-if (!window.__pyodidePromise) {{
-    window.__pyodidePromise = (async () => {{
-        const {{ loadPyodide }} = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
-        const py = await loadPyodide();
-        await py.loadPackage(["micropip"]);
-        await py.runPythonAsync(`
-            import micropip
-            await micropip.install('cryptography')
-        `);
-        return py;
-    }})();
-}}
-const py = await window.__pyodidePromise;
-py.globals.set("csv_data_input", atob(payload.csv_b64));
-py.globals.set("password_input", payload.password);
-py.globals.set("sensitive_columns_input", payload.sensitive);
-py.globals.set("regular_columns_input", payload.regular);
-const result = await py.runPythonAsync(`
-import io, csv, hashlib, base64, json
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.backends import default_backend
-
-def derive_key(password, salt=b'eencijfer_salt_2025'):
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
-                     iterations=100000, backend=default_backend())
-    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
-
-def generate_uuid(pgn):
-    h = hashlib.md5(str(pgn).encode()).hexdigest()
-    return h[:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
-
-cipher = Fernet(derive_key(password_input))
-sensitive_columns = list(sensitive_columns_input)
-regular_columns = list(regular_columns_input)
-rows = list(csv.DictReader(io.StringIO(csv_data_input)))
-
-processed_rows = []
-encrypted_count = 0
-for i, row in enumerate(rows):
-    pgn_value = None
-    for col in row:
-        if col.lower() == 'persoonsgebonden_nummer':
-            pgn_value = row[col]
-            break
-    uuid = generate_uuid(pgn_value) if pgn_value else hashlib.md5(str(i).encode()).hexdigest()
-    processed_row = {{'uuid': uuid}}
-    for col in sensitive_columns:
-        if col in row and row[col]:
-            processed_row[col.lower()] = cipher.encrypt(str(row[col]).encode()).decode()
-            encrypted_count += 1
-        else:
-            processed_row[col.lower()] = ''
-    for col in regular_columns:
-        processed_row[col.lower()] = row.get(col, '')
-    for col in row:
-        if col not in sensitive_columns and col not in regular_columns:
-            processed_row[col] = row[col]
-    processed_rows.append(processed_row)
-
-json.dumps({{"encrypted_count": encrypted_count, "rows": processed_rows}})
-`);
-return result;
-"""
+    return _load_js("upload_personal.js", payload_b64)
 
 
+# st_js_blocking calls st.stop() until the browser component returns a result on
+# a later rerun, so the click must be latched in session_state — gating the work
+# directly on st.button() would drop the async result on the next rerun.
 if st.button("Verwerken & opslaan", type="primary"):
+    st.session_state["upload_personal_running"] = True
+
+if st.session_state.get("upload_personal_running"):
     csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
     js = _build_process_js(csv_base64, password, detected_sensitive, detected_regular)
 
     with st.spinner("Verwerken in uw browser (Pyodide)..."):
         raw = st_js_blocking(js, key="upload_personal_js")
+
+    # Result is in; clear the latch so a rerun doesn't reprocess.
+    st.session_state["upload_personal_running"] = False
 
     try:
         result = json.loads(raw)
@@ -246,10 +202,11 @@ with st.expander("Hoe werkt dit?"):
     **Dataflow:**
     1. CSV wordt in uw browser geladen
     2. Gevoelige kolommen worden gedetecteerd: {', '.join(SENSITIVE_FIELDS)}
-    3. Het wachtwoord leidt een sleutel af (PBKDF2, 100.000 iteraties)
-    4. UUID wordt afgeleid van Persoonsgebonden_nummer (MD5)
+    3. Per record wordt een willekeurige salt gegenereerd; het wachtwoord leidt
+       daarmee een sleutel af (PBKDF2, 100.000 iteraties)
+    4. UUID wordt afgeleid van Persoonsgebonden_nummer (HMAC-SHA256)
     5. Zeer gevoelige kolommen worden versleuteld (Fernet, AES-128-CBC)
-    6. Alleen het **verwerkte** resultaat gaat naar de server
+    6. Alleen het **verwerkte** resultaat (incl. salt, excl. wachtwoord) gaat naar de server
 
     **Opslag:**
     - `secret_sensitive` (PostgreSQL): UUID + versleutelde identifiers

--- a/src/frontend/Files/Upload_Personal_Data.py
+++ b/src/frontend/Files/Upload_Personal_Data.py
@@ -1,18 +1,14 @@
 import base64
 import json
-import os
 from pathlib import Path
 
-import pandas as pd
+import polars as pl
 import streamlit as st
 from streamlit_js import st_js_blocking
 
 from eencijferho.io import personal_data
 
 _JS_DIR = Path(__file__).parent / "js"
-# Key for HMAC-SHA256 UUID derivation; reused from the pseudonymizer config.
-_DEMO_UUID_KEY = "eencijfer-demo-uuid-key-change-me"
-_UUID_KEY = os.getenv("EENCIJFERHO_ENCRYPT_KEY", _DEMO_UUID_KEY)
 
 
 def _load_js(name: str, payload_b64: str) -> str:
@@ -36,19 +32,27 @@ SENSITIVE_FIELDS, REGULAR_FIELDS = _schema()
 st.title("Persoonsgegevens uploaden")
 st.markdown("""
 <div class="page-intro">
-    Upload een CSV met persoonsgegevens. Zeer gevoelige velden worden automatisch
-    <strong>in uw browser</strong> versleuteld. Met één knop wordt de data verwerkt én
-    opgesplitst over PostgreSQL (gevoelig + regulier) en MinIO (overige velden).
+    Upload een CSV met persoonsgegevens. Zeer gevoelige velden worden versleuteld
+    <strong>voordat ze worden opgeslagen</strong>; de database bevat geen leesbare
+    persoonsgegevens. Met één knop wordt de data verwerkt én opgesplitst over
+    PostgreSQL (gevoelig + regulier) en MinIO (overige velden).
 </div>
 """, unsafe_allow_html=True)
+
+if personal_data.is_demo_key():
+    st.warning(
+        "Demo-sleutel actief: er is geen `EENCIJFERHO_ENCRYPT_KEY` ingesteld, dus de "
+        "UUID-afleiding gebruikt een bekende demo-sleutel. Niet gebruiken voor echte data."
+    )
 
 st.markdown("""
 **Stappen:**
 1. Upload een CSV met persoonsgegevens
 2. Het systeem detecteert gevoelige kolommen automatisch
 3. Voer een wachtwoord in
-4. Klik op **Verwerken & opslaan** — versleuteling + UUID-afleiding gebeuren in uw
-   browser, daarna wordt de data opgeslagen (downloaden blijft optioneel)
+4. Klik op **Verwerken & opslaan** — de gevoelige kolommen worden in uw browser
+   versleuteld; de UUID wordt server-side afgeleid. Daarna wordt de data opgeslagen
+   (downloaden blijft optioneel)
 """)
 
 st.markdown("---")
@@ -64,7 +68,7 @@ if uploaded_file is None:
     st.stop()
 
 try:
-    df = pd.read_csv(uploaded_file)
+    df = pl.read_csv(uploaded_file, infer_schema_length=0)
 except Exception as e:
     st.error(f"Fout bij lezen van CSV: {e}")
     st.stop()
@@ -130,7 +134,8 @@ st.warning("Onthoud dit wachtwoord — u heeft het nodig om de data later te ont
 
 st.caption(
     "De eerste keer duurt het laden van Pyodide in uw browser 10-20 seconden. "
-    "Versleuteling en UUID-afleiding gebeuren volledig lokaal."
+    "De versleuteling van gevoelige kolommen gebeurt lokaal; de UUID wordt "
+    "server-side afgeleid met een sleutel die de browser nooit ziet."
 )
 
 
@@ -140,7 +145,6 @@ def _build_process_js(csv_b64: str, password: str,
     payload = json.dumps({
         "csv_b64": csv_b64,
         "password": password,
-        "uuid_key": _UUID_KEY,
         "sensitive": sensitive,
         "regular": regular,
     })
@@ -155,7 +159,7 @@ if st.button("Verwerken & opslaan", type="primary"):
     st.session_state["upload_personal_running"] = True
 
 if st.session_state.get("upload_personal_running"):
-    csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
+    csv_base64 = base64.b64encode(df.write_csv().encode()).decode()
     js = _build_process_js(csv_base64, password, detected_sensitive, detected_regular)
 
     with st.spinner("Verwerken in uw browser (Pyodide)..."):
@@ -204,9 +208,12 @@ with st.expander("Hoe werkt dit?"):
     2. Gevoelige kolommen worden gedetecteerd: {', '.join(SENSITIVE_FIELDS)}
     3. Per record wordt een willekeurige salt gegenereerd; het wachtwoord leidt
        daarmee een sleutel af (PBKDF2, 100.000 iteraties)
-    4. UUID wordt afgeleid van Persoonsgebonden_nummer (HMAC-SHA256)
-    5. Zeer gevoelige kolommen worden versleuteld (Fernet, AES-128-CBC)
-    6. Alleen het **verwerkte** resultaat (incl. salt, excl. wachtwoord) gaat naar de server
+    4. Zeer gevoelige kolommen worden versleuteld (Fernet, AES-128-CBC)
+    5. De server leidt de UUID af uit het Persoonsgebonden_nummer (HMAC-SHA256 met
+       een serversleutel die de browser nooit ziet); het plaintext-nummer wordt
+       daarbij niet opgeslagen
+    6. Alleen het versleutelde resultaat + de bron voor UUID-afleiding gaat naar de
+       server (excl. wachtwoord)
 
     **Opslag:**
     - `secret_sensitive` (PostgreSQL): UUID + versleutelde identifiers

--- a/src/frontend/Files/Upload_Personal_Data.py
+++ b/src/frontend/Files/Upload_Personal_Data.py
@@ -14,7 +14,7 @@ _JS_DIR = Path(__file__).parent / "js"
 def _load_js(name: str, payload_b64: str) -> str:
     template = (_JS_DIR / name).read_text(encoding="utf-8")
     bootstrap = (_JS_DIR / "_pyodide_bootstrap.js").read_text(encoding="utf-8")
-    return template.replace("__PYODIDE_BOOTSTRAP__", bootstrap).replace(
+    return template.replace("// __PYODIDE_BOOTSTRAP__", bootstrap).replace(
         "__PAYLOAD_B64__", payload_b64
     )
 

--- a/src/frontend/Files/Upload_Personal_Data.py
+++ b/src/frontend/Files/Upload_Personal_Data.py
@@ -1,0 +1,258 @@
+import base64
+import json
+
+import pandas as pd
+import streamlit as st
+from streamlit_js import st_js_blocking
+
+from eencijferho.io import personal_data
+
+# -----------------------------------------------------------------------------
+# Schema (column names) from the database, with defaults as fallback
+# -----------------------------------------------------------------------------
+@st.cache_data(ttl=300)
+def _schema() -> tuple[list[str], list[str]]:
+    s = personal_data.get_schema()
+    return s["sensitive_columns"], s["regular_columns"]
+
+
+SENSITIVE_FIELDS, REGULAR_FIELDS = _schema()
+
+# -----------------------------------------------------------------------------
+# Page Header
+# -----------------------------------------------------------------------------
+st.title("Persoonsgegevens uploaden")
+st.markdown("""
+<div class="page-intro">
+    Upload een CSV met persoonsgegevens. Zeer gevoelige velden worden automatisch
+    <strong>in uw browser</strong> versleuteld. Met één knop wordt de data verwerkt én
+    opgesplitst over PostgreSQL (gevoelig + regulier) en MinIO (overige velden).
+</div>
+""", unsafe_allow_html=True)
+
+st.markdown("""
+**Stappen:**
+1. Upload een CSV met persoonsgegevens
+2. Het systeem detecteert gevoelige kolommen automatisch
+3. Voer een wachtwoord in
+4. Klik op **Verwerken & opslaan** — versleuteling + UUID-afleiding gebeuren in uw
+   browser, daarna wordt de data opgeslagen (downloaden blijft optioneel)
+""")
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 1 — Upload CSV
+# -----------------------------------------------------------------------------
+st.subheader("Stap 1 · CSV-bestand uploaden")
+
+uploaded_file = st.file_uploader("Kies een CSV met persoonsgegevens", type=["csv"])
+if uploaded_file is None:
+    st.info("Upload een CSV-bestand om te beginnen.")
+    st.stop()
+
+try:
+    df = pd.read_csv(uploaded_file)
+except Exception as e:
+    st.error(f"Fout bij lezen van CSV: {e}")
+    st.stop()
+
+st.success(f"Bestand geladen: {uploaded_file.name}")
+st.write(f"**Rijen:** {len(df)} · **Kolommen:** {len(df.columns)}")
+with st.expander("Data bekijken"):
+    st.dataframe(df.head(10))
+
+
+def _find_matching(schema_cols: list[str], df_cols) -> list[str]:
+    lower = {c.lower(): c for c in df_cols}
+    return [lower[c.lower()] for c in schema_cols if c.lower() in lower]
+
+
+detected_sensitive = _find_matching(SENSITIVE_FIELDS, df.columns)
+detected_regular = _find_matching(REGULAR_FIELDS, df.columns)
+
+st.markdown("---")
+st.subheader("Stap 2 · Gedetecteerde kolommen")
+col1, col2 = st.columns(2)
+with col1:
+    st.write("**Zeer gevoelig (wordt versleuteld):**")
+    if detected_sensitive:
+        for c in detected_sensitive:
+            st.write(f"🔒 {c}")
+    else:
+        st.warning("Geen zeer gevoelige kolommen gedetecteerd")
+with col2:
+    st.write("**Regulier (opgeslagen zoals het is):**")
+    if detected_regular:
+        for c in detected_regular:
+            st.write(f"📋 {c}")
+    else:
+        st.info("Geen reguliere kolommen gedetecteerd")
+
+# Persoonsgebonden_nummer is required for UUID generation (case-insensitive).
+pgn_col = next((c for c in df.columns if c.lower() == "persoonsgebonden_nummer"), None)
+if pgn_col is None:
+    st.error("Verplichte kolom ontbreekt: Persoonsgebonden_nummer (nodig voor UUID).")
+    st.stop()
+if not detected_sensitive:
+    st.error("Geen zeer gevoelige kolommen gedetecteerd. Kan niet doorgaan.")
+    st.stop()
+
+st.markdown("---")
+
+# -----------------------------------------------------------------------------
+# Step 3 — Encrypt + process in browser + store, with one button
+# -----------------------------------------------------------------------------
+st.subheader("Stap 3 · Verwerken & opslaan")
+
+password = st.text_input(
+    "Voer een versleutelwachtwoord in",
+    type="password",
+    help="Dit wachtwoord versleutelt de zeer gevoelige kolommen in uw browser.",
+)
+if not password:
+    st.info("Voer een wachtwoord in om versleuteling in te schakelen.")
+    st.stop()
+
+st.warning("Onthoud dit wachtwoord — u heeft het nodig om de data later te ontsleutelen.")
+
+st.caption(
+    "De eerste keer duurt het laden van Pyodide in uw browser 10-20 seconden. "
+    "Versleuteling en UUID-afleiding gebeuren volledig lokaal."
+)
+
+
+def _build_process_js(csv_b64: str, password: str,
+                      sensitive: list[str], regular: list[str]) -> str:
+    """JS that loads Pyodide, encrypts sensitive cols + derives UUID, returns rows JSON."""
+    payload = json.dumps({
+        "csv_b64": csv_b64,
+        "password": password,
+        "sensitive": sensitive,
+        "regular": regular,
+    })
+    payload_b64 = base64.b64encode(payload.encode()).decode()
+    return f"""
+const payload = JSON.parse(atob("{payload_b64}"));
+if (!window.__pyodidePromise) {{
+    window.__pyodidePromise = (async () => {{
+        const {{ loadPyodide }} = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`
+            import micropip
+            await micropip.install('cryptography')
+        `);
+        return py;
+    }})();
+}}
+const py = await window.__pyodidePromise;
+py.globals.set("csv_data_input", atob(payload.csv_b64));
+py.globals.set("password_input", payload.password);
+py.globals.set("sensitive_columns_input", payload.sensitive);
+py.globals.set("regular_columns_input", payload.regular);
+const result = await py.runPythonAsync(`
+import io, csv, hashlib, base64, json
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt=b'eencijfer_salt_2025'):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+def generate_uuid(pgn):
+    h = hashlib.md5(str(pgn).encode()).hexdigest()
+    return h[:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+
+cipher = Fernet(derive_key(password_input))
+sensitive_columns = list(sensitive_columns_input)
+regular_columns = list(regular_columns_input)
+rows = list(csv.DictReader(io.StringIO(csv_data_input)))
+
+processed_rows = []
+encrypted_count = 0
+for i, row in enumerate(rows):
+    pgn_value = None
+    for col in row:
+        if col.lower() == 'persoonsgebonden_nummer':
+            pgn_value = row[col]
+            break
+    uuid = generate_uuid(pgn_value) if pgn_value else hashlib.md5(str(i).encode()).hexdigest()
+    processed_row = {{'uuid': uuid}}
+    for col in sensitive_columns:
+        if col in row and row[col]:
+            processed_row[col.lower()] = cipher.encrypt(str(row[col]).encode()).decode()
+            encrypted_count += 1
+        else:
+            processed_row[col.lower()] = ''
+    for col in regular_columns:
+        processed_row[col.lower()] = row.get(col, '')
+    for col in row:
+        if col not in sensitive_columns and col not in regular_columns:
+            processed_row[col] = row[col]
+    processed_rows.append(processed_row)
+
+json.dumps({{"encrypted_count": encrypted_count, "rows": processed_rows}})
+`);
+return result;
+"""
+
+
+if st.button("Verwerken & opslaan", type="primary"):
+    csv_base64 = base64.b64encode(df.to_csv(index=False).encode()).decode()
+    js = _build_process_js(csv_base64, password, detected_sensitive, detected_regular)
+
+    with st.spinner("Verwerken in uw browser (Pyodide)..."):
+        raw = st_js_blocking(js, key="upload_personal_js")
+
+    try:
+        result = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        st.error("Verwerking in de browser is mislukt of niet voltooid. Probeer opnieuw.")
+        st.stop()
+
+    rows = result["rows"]
+    encrypted_count = result["encrypted_count"]
+    st.success(f"{len(rows)} rijen verwerkt, {encrypted_count} waarden versleuteld.")
+
+    try:
+        with st.spinner("Opslaan in database en object-opslag..."):
+            store_result = personal_data.upload_personal_data(rows)
+    except Exception as e:
+        st.error(f"Fout bij opslaan: {e}")
+        st.info("Controleer of de PostgreSQL- en MinIO-containers draaien (`docker compose up`).")
+        st.stop()
+
+    st.success(f"Opgeslagen: {store_result['inserted']} records.")
+    st.json(store_result)
+
+    st.download_button(
+        "Verwerkt JSON downloaden (optioneel)",
+        data=json.dumps(rows, indent=2).encode(),
+        file_name="processed_personal_data.json",
+        mime="application/json",
+    )
+    st.balloons()
+
+# -----------------------------------------------------------------------------
+# Info
+# -----------------------------------------------------------------------------
+st.markdown("---")
+with st.expander("Hoe werkt dit?"):
+    st.markdown(f"""
+    **Dataflow:**
+    1. CSV wordt in uw browser geladen
+    2. Gevoelige kolommen worden gedetecteerd: {', '.join(SENSITIVE_FIELDS)}
+    3. Het wachtwoord leidt een sleutel af (PBKDF2, 100.000 iteraties)
+    4. UUID wordt afgeleid van Persoonsgebonden_nummer (MD5)
+    5. Zeer gevoelige kolommen worden versleuteld (Fernet, AES-128-CBC)
+    6. Alleen het **verwerkte** resultaat gaat naar de server
+
+    **Opslag:**
+    - `secret_sensitive` (PostgreSQL): UUID + versleutelde identifiers
+    - `secret_regular` (PostgreSQL): UUID + demografische velden
+    - MinIO: UUID + overige niet-gevoelige velden, als JSON-object
+    """)

--- a/src/frontend/Files/js/_pyodide_bootstrap.js
+++ b/src/frontend/Files/js/_pyodide_bootstrap.js
@@ -1,0 +1,16 @@
+// Shared Pyodide bootstrap for the st_js pages. Loads Pyodide once per browser
+// session (cached on window) and installs the cryptography package. Injected
+// into the page scripts by the _load_js helper.
+if (!window.__pyodidePromise) {
+    window.__pyodidePromise = (async () => {
+        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`
+            import micropip
+            await micropip.install('cryptography')
+        `);
+        return py;
+    })();
+}
+const py = await window.__pyodidePromise;

--- a/src/frontend/Files/js/decrypt_personal.html
+++ b/src/frontend/Files/js/decrypt_personal.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="nl">
 <head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+    <meta charset="utf-8">
+    <title>Persoonsgegevens ontsleutelen</title>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"
+            integrity="sha384-+R8PTzDXzivdjpxOqwVwRhPS9dlske7tKAjwj0O0Kr361gKY5d2Xe6Osl+faRLT7"
+            crossorigin="anonymous"></script>
     <style>
         body { font-family: 'Source Sans Pro', sans-serif; padding: 20px; }
         .status { padding: 15px; margin: 10px 0; border-radius: 5px; font-size: 14px; }

--- a/src/frontend/Files/js/decrypt_personal.html
+++ b/src/frontend/Files/js/decrypt_personal.html
@@ -87,22 +87,47 @@ str(decrypted_count) + "||" + json.dumps(data)
 
                 const parts = result.split('||', 2);
                 const decrypted = JSON.parse(parts[1]);
-                let html = '<strong>Ontsleuteld: ' + parts[0] + ' waarden.</strong><br><br>';
+
+                // Build the table with DOM nodes and textContent so decrypted cell
+                // values are never interpreted as HTML (prevents stored XSS).
+                const preview = document.getElementById('preview');
+                preview.replaceChildren();
+                const heading = document.createElement('strong');
+                heading.textContent = 'Ontsleuteld: ' + parts[0] + ' waarden.';
+                preview.appendChild(heading);
+
                 if (decrypted.length > 0) {
-                    html += '<table><thead><tr>';
-                    for (let key in decrypted[0]) html += '<th>' + key + '</th>';
-                    html += '</tr></thead><tbody>';
-                    for (let i = 0; i < Math.min(decrypted.length, 20); i++) {
-                        html += '<tr>';
-                        for (let key in decrypted[i]) html += '<td>' + (decrypted[i][key] ?? '') + '</td>';
-                        html += '</tr>';
+                    const table = document.createElement('table');
+                    const thead = document.createElement('thead');
+                    const headRow = document.createElement('tr');
+                    for (let key in decrypted[0]) {
+                        const th = document.createElement('th');
+                        th.textContent = key;
+                        headRow.appendChild(th);
                     }
-                    html += '</tbody></table>';
-                    if (decrypted.length > 20)
-                        html += '<br><em>Eerste 20 van ' + decrypted.length + ' records.</em>';
+                    thead.appendChild(headRow);
+                    table.appendChild(thead);
+
+                    const tbody = document.createElement('tbody');
+                    for (let i = 0; i < Math.min(decrypted.length, 20); i++) {
+                        const tr = document.createElement('tr');
+                        for (let key in decrypted[i]) {
+                            const td = document.createElement('td');
+                            td.textContent = decrypted[i][key] ?? '';
+                            tr.appendChild(td);
+                        }
+                        tbody.appendChild(tr);
+                    }
+                    table.appendChild(tbody);
+                    preview.appendChild(table);
+
+                    if (decrypted.length > 20) {
+                        const note = document.createElement('em');
+                        note.textContent = 'Eerste 20 van ' + decrypted.length + ' records.';
+                        preview.appendChild(note);
+                    }
                 }
-                document.getElementById('preview').innerHTML = html;
-                document.getElementById('status').innerHTML = 'Klaar! ' + parts[0] + ' waarden ontsleuteld.';
+                document.getElementById('status').textContent = 'Klaar! ' + parts[0] + ' waarden ontsleuteld.';
                 document.getElementById('status').className = 'status success';
             } catch (error) {
                 document.getElementById('status').innerHTML =

--- a/src/frontend/Files/js/decrypt_personal.html
+++ b/src/frontend/Files/js/decrypt_personal.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+    <style>
+        body { font-family: 'Source Sans Pro', sans-serif; padding: 20px; }
+        .status { padding: 15px; margin: 10px 0; border-radius: 5px; font-size: 14px; }
+        .loading { background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; }
+        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        table { width: 100%; border-collapse: collapse; font-size: 12px; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; font-weight: bold; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+        #preview { max-height: 420px; overflow: auto; margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <div id="status" class="status loading">Pyodide initialiseren...</div>
+    <div id="preview"></div>
+
+    <script type="text/javascript">
+        // All inputs (data, password, sensitive fields) arrive as one base64 JSON
+        // blob and are passed to Python via globals.set — never interpolated into
+        // source, so a password can never break out into executable code.
+        const payload = JSON.parse(atob('__PAYLOAD_B64__'));
+        let pyodide;
+
+        async function initPyodide() {
+            try {
+                document.getElementById('status').innerHTML = 'Pyodide laden (10-20 seconden)...';
+                pyodide = await loadPyodide();
+                document.getElementById('status').innerHTML = 'cryptography installeren...';
+                await pyodide.loadPackage(['micropip']);
+                await pyodide.runPythonAsync(`
+                    import micropip
+                    await micropip.install('cryptography')
+                `);
+                decryptData();
+            } catch (error) {
+                document.getElementById('status').innerHTML = 'Fout bij laden Pyodide: ' + error;
+                document.getElementById('status').className = 'status error';
+                console.error(error);
+            }
+        }
+
+        async function decryptData() {
+            try {
+                document.getElementById('status').innerHTML = 'Data ontsleutelen in browser...';
+                document.getElementById('status').className = 'status loading';
+
+                pyodide.globals.set('data_input', atob(payload.data_b64));
+                pyodide.globals.set('password_input', payload.password);
+                pyodide.globals.set('sensitive_fields_input', payload.sensitive_fields);
+
+                const result = await pyodide.runPythonAsync(`
+import json, base64
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+data = json.loads(data_input)
+sensitive_fields = sensitive_fields_input
+decrypted_count = 0
+for row in data:
+    # Each record was encrypted with its own salt; re-derive that row's key.
+    salt_b64 = row.get('salt')
+    if not salt_b64:
+        continue
+    cipher = Fernet(derive_key(password_input, base64.b64decode(salt_b64)))
+    for field in sensitive_fields:
+        if field in row and row[field]:
+            try:
+                row[field] = cipher.decrypt(row[field].encode()).decode()
+                decrypted_count += 1
+            except Exception as e:
+                row[field] = "DECRYPT_ERROR"
+    row.pop('salt', None)
+str(decrypted_count) + "||" + json.dumps(data)
+                `);
+
+                const parts = result.split('||', 2);
+                const decrypted = JSON.parse(parts[1]);
+                let html = '<strong>Ontsleuteld: ' + parts[0] + ' waarden.</strong><br><br>';
+                if (decrypted.length > 0) {
+                    html += '<table><thead><tr>';
+                    for (let key in decrypted[0]) html += '<th>' + key + '</th>';
+                    html += '</tr></thead><tbody>';
+                    for (let i = 0; i < Math.min(decrypted.length, 20); i++) {
+                        html += '<tr>';
+                        for (let key in decrypted[i]) html += '<td>' + (decrypted[i][key] ?? '') + '</td>';
+                        html += '</tr>';
+                    }
+                    html += '</tbody></table>';
+                    if (decrypted.length > 20)
+                        html += '<br><em>Eerste 20 van ' + decrypted.length + ' records.</em>';
+                }
+                document.getElementById('preview').innerHTML = html;
+                document.getElementById('status').innerHTML = 'Klaar! ' + parts[0] + ' waarden ontsleuteld.';
+                document.getElementById('status').className = 'status success';
+            } catch (error) {
+                document.getElementById('status').innerHTML =
+                    'Ontsleutelfout: ' + error + ' — controleer het wachtwoord.';
+                document.getElementById('status').className = 'status error';
+                console.error(error);
+            }
+        }
+
+        initPyodide();
+    </script>
+</body>
+</html>

--- a/src/frontend/Files/js/encrypt_upload.js
+++ b/src/frontend/Files/js/encrypt_upload.js
@@ -1,0 +1,51 @@
+// Encrypts a chosen column in the browser via Pyodide. Inputs arrive as a
+// single base64 JSON blob (__PAYLOAD_B64__) and are passed to Python as data.
+// Each row gets its own random PBKDF2 salt, written to a `salt` column so the
+// value can be decrypted later without a shared, source-baked salt.
+const payload = JSON.parse(atob("__PAYLOAD_B64__"));
+if (!window.__pyodidePromise) {
+    window.__pyodidePromise = (async () => {
+        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`
+            import micropip
+            await micropip.install('cryptography')
+        `);
+        return py;
+    })();
+}
+const py = await window.__pyodidePromise;
+py.globals.set("csv_data_input", atob(payload.csv_b64));
+py.globals.set("password_input", payload.password);
+py.globals.set("column_name_input", payload.column);
+const result = await py.runPythonAsync(`
+import io, csv, os, base64
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+rows = list(csv.DictReader(io.StringIO(csv_data_input)))
+encrypted_count = 0
+for row in rows:
+    salt = os.urandom(16)
+    row['salt'] = base64.b64encode(salt).decode()
+    if column_name_input in row and row[column_name_input]:
+        cipher = Fernet(derive_key(password_input, salt))
+        row[column_name_input] = cipher.encrypt(row[column_name_input].encode()).decode()
+        encrypted_count += 1
+output = io.StringIO()
+if rows:
+    writer = csv.DictWriter(output, fieldnames=rows[0].keys())
+    writer.writeheader()
+    writer.writerows(rows)
+import json as _json
+_json.dumps({"encrypted_count": encrypted_count, "csv": output.getvalue()})
+`);
+return result;

--- a/src/frontend/Files/js/encrypt_upload.js
+++ b/src/frontend/Files/js/encrypt_upload.js
@@ -3,7 +3,7 @@
 // Each row gets its own random PBKDF2 salt, written to a `salt` column so the
 // value can be decrypted later without a shared, source-baked salt.
 const payload = JSON.parse(atob("__PAYLOAD_B64__"));
-__PYODIDE_BOOTSTRAP__
+// __PYODIDE_BOOTSTRAP__
 py.globals.set("csv_data_input", atob(payload.csv_b64));
 py.globals.set("password_input", payload.password);
 py.globals.set("column_name_input", payload.column);

--- a/src/frontend/Files/js/encrypt_upload.js
+++ b/src/frontend/Files/js/encrypt_upload.js
@@ -3,19 +3,7 @@
 // Each row gets its own random PBKDF2 salt, written to a `salt` column so the
 // value can be decrypted later without a shared, source-baked salt.
 const payload = JSON.parse(atob("__PAYLOAD_B64__"));
-if (!window.__pyodidePromise) {
-    window.__pyodidePromise = (async () => {
-        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
-        const py = await loadPyodide();
-        await py.loadPackage(["micropip"]);
-        await py.runPythonAsync(`
-            import micropip
-            await micropip.install('cryptography')
-        `);
-        return py;
-    })();
-}
-const py = await window.__pyodidePromise;
+__PYODIDE_BOOTSTRAP__
 py.globals.set("csv_data_input", atob(payload.csv_b64));
 py.globals.set("password_input", payload.password);
 py.globals.set("column_name_input", payload.column);

--- a/src/frontend/Files/js/upload_personal.js
+++ b/src/frontend/Files/js/upload_personal.js
@@ -3,7 +3,7 @@
 // (__PAYLOAD_B64__) and are handed to Python as data via globals.set — nothing
 // from user input is ever interpolated into source code.
 const payload = JSON.parse(atob("__PAYLOAD_B64__"));
-__PYODIDE_BOOTSTRAP__
+// __PYODIDE_BOOTSTRAP__
 py.globals.set("csv_data_input", atob(payload.csv_b64));
 py.globals.set("password_input", payload.password);
 py.globals.set("sensitive_columns_input", payload.sensitive);

--- a/src/frontend/Files/js/upload_personal.js
+++ b/src/frontend/Files/js/upload_personal.js
@@ -3,19 +3,7 @@
 // (__PAYLOAD_B64__) and are handed to Python as data via globals.set — nothing
 // from user input is ever interpolated into source code.
 const payload = JSON.parse(atob("__PAYLOAD_B64__"));
-if (!window.__pyodidePromise) {
-    window.__pyodidePromise = (async () => {
-        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
-        const py = await loadPyodide();
-        await py.loadPackage(["micropip"]);
-        await py.runPythonAsync(`
-            import micropip
-            await micropip.install('cryptography')
-        `);
-        return py;
-    })();
-}
-const py = await window.__pyodidePromise;
+__PYODIDE_BOOTSTRAP__
 py.globals.set("csv_data_input", atob(payload.csv_b64));
 py.globals.set("password_input", payload.password);
 py.globals.set("sensitive_columns_input", payload.sensitive);

--- a/src/frontend/Files/js/upload_personal.js
+++ b/src/frontend/Files/js/upload_personal.js
@@ -18,11 +18,10 @@ if (!window.__pyodidePromise) {
 const py = await window.__pyodidePromise;
 py.globals.set("csv_data_input", atob(payload.csv_b64));
 py.globals.set("password_input", payload.password);
-py.globals.set("uuid_key_input", payload.uuid_key);
 py.globals.set("sensitive_columns_input", payload.sensitive);
 py.globals.set("regular_columns_input", payload.regular);
 const result = await py.runPythonAsync(`
-import io, csv, os, hmac, hashlib, base64, json
+import io, csv, os, base64, json
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -32,10 +31,6 @@ def derive_key(password, salt):
     kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
                      iterations=100000, backend=default_backend())
     return base64.urlsafe_b64encode(kdf.derive(password.encode()))
-
-def generate_uuid(pgn):
-    h = hmac.new(uuid_key_input.encode(), str(pgn).encode(), hashlib.sha256).hexdigest()
-    return h[:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
 
 sensitive_columns = list(sensitive_columns_input)
 regular_columns = list(regular_columns_input)
@@ -49,13 +44,16 @@ for i, row in enumerate(rows):
         if col.lower() == 'persoonsgebonden_nummer':
             pgn_value = row[col]
             break
-    uuid = generate_uuid(pgn_value) if pgn_value else generate_uuid("row-" + str(i))
 
     # Fresh random salt per record; the key is derived from password + this salt.
     salt = os.urandom(16)
     cipher = Fernet(derive_key(password_input, salt))
 
-    processed_row = {'uuid': uuid, 'salt': base64.b64encode(salt).decode()}
+    # The UUID is derived server-side (HMAC with a secret key that never reaches
+    # the browser). We pass the value to derive from; the server discards it and
+    # never stores the plaintext PGN.
+    uuid_source = pgn_value if pgn_value else "row-" + str(i)
+    processed_row = {'__uuid_source': uuid_source, 'salt': base64.b64encode(salt).decode()}
     for col in sensitive_columns:
         if col in row and row[col]:
             processed_row[col.lower()] = cipher.encrypt(str(row[col]).encode()).decode()

--- a/src/frontend/Files/js/upload_personal.js
+++ b/src/frontend/Files/js/upload_personal.js
@@ -1,0 +1,74 @@
+// Encrypts sensitive columns and derives a UUID, entirely in the browser via
+// Pyodide. All inputs arrive as a single base64-encoded JSON blob
+// (__PAYLOAD_B64__) and are handed to Python as data via globals.set — nothing
+// from user input is ever interpolated into source code.
+const payload = JSON.parse(atob("__PAYLOAD_B64__"));
+if (!window.__pyodidePromise) {
+    window.__pyodidePromise = (async () => {
+        const { loadPyodide } = await import("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.mjs");
+        const py = await loadPyodide();
+        await py.loadPackage(["micropip"]);
+        await py.runPythonAsync(`
+            import micropip
+            await micropip.install('cryptography')
+        `);
+        return py;
+    })();
+}
+const py = await window.__pyodidePromise;
+py.globals.set("csv_data_input", atob(payload.csv_b64));
+py.globals.set("password_input", payload.password);
+py.globals.set("uuid_key_input", payload.uuid_key);
+py.globals.set("sensitive_columns_input", payload.sensitive);
+py.globals.set("regular_columns_input", payload.regular);
+const result = await py.runPythonAsync(`
+import io, csv, os, hmac, hashlib, base64, json
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+def derive_key(password, salt):
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
+                     iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
+def generate_uuid(pgn):
+    h = hmac.new(uuid_key_input.encode(), str(pgn).encode(), hashlib.sha256).hexdigest()
+    return h[:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+
+sensitive_columns = list(sensitive_columns_input)
+regular_columns = list(regular_columns_input)
+rows = list(csv.DictReader(io.StringIO(csv_data_input)))
+
+processed_rows = []
+encrypted_count = 0
+for i, row in enumerate(rows):
+    pgn_value = None
+    for col in row:
+        if col.lower() == 'persoonsgebonden_nummer':
+            pgn_value = row[col]
+            break
+    uuid = generate_uuid(pgn_value) if pgn_value else generate_uuid("row-" + str(i))
+
+    # Fresh random salt per record; the key is derived from password + this salt.
+    salt = os.urandom(16)
+    cipher = Fernet(derive_key(password_input, salt))
+
+    processed_row = {'uuid': uuid, 'salt': base64.b64encode(salt).decode()}
+    for col in sensitive_columns:
+        if col in row and row[col]:
+            processed_row[col.lower()] = cipher.encrypt(str(row[col]).encode()).decode()
+            encrypted_count += 1
+        else:
+            processed_row[col.lower()] = ''
+    for col in regular_columns:
+        processed_row[col.lower()] = row.get(col, '')
+    for col in row:
+        if col not in sensitive_columns and col not in regular_columns:
+            processed_row[col] = row[col]
+    processed_rows.append(processed_row)
+
+json.dumps({"encrypted_count": encrypted_count, "rows": processed_rows})
+`);
+return result;

--- a/src/main.py
+++ b/src/main.py
@@ -121,6 +121,15 @@ documentation_page = st.Page(
 data_upload_page = st.Page(
     "frontend/Files/Upload_Data.py", icon="📁", title="Bestanden uploaden"
 )
+encrypt_upload_page = st.Page(
+    "frontend/Files/Encrypt_Upload.py", icon="🔐", title="Versleutelen & uploaden"
+)
+personal_data_page = st.Page(
+    "frontend/Files/Upload_Personal_Data.py", icon="👤", title="Persoonsgegevens uploaden"
+)
+browse_personal_page = st.Page(
+    "frontend/Files/Browse_Personal_Data.py", icon="📂", title="Persoonsgegevens bekijken"
+)
 
 extract_page = st.Page(
     "frontend/Modules/Extract_Metadata.py", icon="🔍", title="Stap 1 · Metadata extraheren"
@@ -150,7 +159,7 @@ show_version_notification()
 pg = st.navigation(
     {
         "Overview": [home_page, documentation_page],
-        "Files": [data_upload_page],
+        "Files": [data_upload_page, encrypt_upload_page, personal_data_page, browse_personal_page],
         "Modules": [extract_page, validate_page, turbo_convert_page, validate_output_page, tip_page],
     }
 )

--- a/tests/eencijferho/test_personal_data_security.py
+++ b/tests/eencijferho/test_personal_data_security.py
@@ -1,0 +1,106 @@
+"""Beveiligingsregressietests voor de personal-data demo.
+
+Deze tests borgen de fixes uit de code-review op PR #147:
+
+- Server-side UUID-afleiding (de HMAC-sleutel mag nooit naar de browser).
+- Geen plaintext-identifier in de opslag-payload.
+- XSS-fix in de client-side ontsleutel-render (textContent i.p.v. innerHTML).
+- Geen misleidende "verlaat uw browser nooit"-belofte meer.
+
+De JS-tests zijn *regressiewachters*: ze parsen de asset-bestanden en
+controleren op (on)veilige patronen. Ze draaien in de bestaande Python-CI
+zonder browser of Node-toolchain — ze bewijzen geen browsergedrag, maar
+vangen het opnieuw introduceren van de kwetsbare patronen af.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from eencijferho.io import personal_data
+
+_JS_DIR = Path(__file__).resolve().parents[2] / "src" / "frontend" / "Files" / "js"
+
+
+def _read(name: str) -> str:
+    return (_JS_DIR / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Server-side UUID-afleiding (#1)
+# ---------------------------------------------------------------------------
+
+def test_derive_uuid_is_deterministic():
+    assert personal_data.derive_uuid("123456789") == personal_data.derive_uuid("123456789")
+
+
+def test_derive_uuid_is_source_sensitive():
+    assert personal_data.derive_uuid("123456789") != personal_data.derive_uuid("987654321")
+
+
+def test_derive_uuid_has_uuid_shape():
+    uuid = personal_data.derive_uuid("123456789")
+    parts = uuid.split("-")
+    assert [len(p) for p in parts] == [8, 4, 4, 4, 12]
+
+
+def test_derive_uuid_depends_on_key(monkeypatch):
+    monkeypatch.setenv(personal_data.ENCRYPT_KEY_ENV, "a" * 64)
+    with_key_a = personal_data.derive_uuid("123456789")
+    monkeypatch.setenv(personal_data.ENCRYPT_KEY_ENV, "b" * 64)
+    with_key_b = personal_data.derive_uuid("123456789")
+    assert with_key_a != with_key_b
+
+
+def test_is_demo_key_reflects_env(monkeypatch):
+    monkeypatch.delenv(personal_data.ENCRYPT_KEY_ENV, raising=False)
+    assert personal_data.is_demo_key() is True
+    monkeypatch.setenv(personal_data.ENCRYPT_KEY_ENV, "x" * 64)
+    assert personal_data.is_demo_key() is False
+
+
+def test_uuid_key_never_appears_in_upload_js():
+    """The browser payload must not carry the HMAC key or derive UUIDs itself."""
+    js = _read("upload_personal.js")
+    assert "uuid_key" not in js
+    assert "generate_uuid" not in js
+    # The browser sends a value to derive from; the server does the HMAC.
+    assert "__uuid_source" in js
+
+
+# ---------------------------------------------------------------------------
+# XSS-regressiewachter voor de ontsleutel-render (#2)
+# ---------------------------------------------------------------------------
+
+def test_decrypt_render_uses_textcontent():
+    html = _read("decrypt_personal.html")
+    assert "textContent" in html
+    assert "createElement" in html
+
+
+def test_decrypt_render_has_no_unsafe_cell_concatenation():
+    """The vulnerable '<td>' + value + '</td>' innerHTML pattern must be gone."""
+    html = _read("decrypt_personal.html")
+    assert "'<td>'" not in html
+    assert "'<th>'" not in html
+    # No innerHTML assignment of a built-up html string in the render path.
+    assert "innerHTML = html" not in html
+
+
+# ---------------------------------------------------------------------------
+# Geen misleidende privacy-belofte (#3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "page",
+    [
+        "Upload_Personal_Data.py",
+        "Browse_Personal_Data.py",
+        "Encrypt_Upload.py",
+    ],
+)
+def test_pages_drop_never_leaves_browser_claim(page):
+    frontend = Path(__file__).resolve().parents[2] / "src" / "frontend" / "Files"
+    text = (frontend / page).read_text(encoding="utf-8")
+    assert "verlaat uw browser nooit" not in text
+    assert "nooit naar de server" not in text

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -123,3 +123,45 @@ def minio_env(minio_service, monkeypatch):
     monkeypatch.setenv("MINIO_SECRET_KEY", "minioadmin")
     monkeypatch.setenv("MINIO_BUCKET", TEST_BUCKET)
     monkeypatch.setenv("MINIO_SECURE", "false")
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL — used by the personal-data store (needs MinIO + Postgres together)
+# ---------------------------------------------------------------------------
+
+def _postgres_available() -> bool:
+    """Check if a Postgres instance is reachable with the test credentials."""
+    try:
+        import psycopg2
+    except ImportError:
+        return False
+    try:
+        conn = psycopg2.connect(
+            host="localhost", port=5432, dbname="cijferho",
+            user="postgres", password="postgres", connect_timeout=3,
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def personal_data_env(minio_service, monkeypatch):
+    """Point both MinIO and Postgres backends at the local test instances.
+
+    Skips when Postgres is unavailable — the personal-data store splits records
+    across both, so it needs a live Postgres in addition to MinIO.
+    """
+    if not _postgres_available():
+        pytest.skip("PostgreSQL not available")
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "minioadmin")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "minioadmin")
+    monkeypatch.setenv("MINIO_BUCKET", TEST_BUCKET)
+    monkeypatch.setenv("MINIO_SECURE", "false")
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DATABASE", "cijferho")
+    monkeypatch.setenv("POSTGRES_USER", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")

--- a/tests/integration/test_personal_data.py
+++ b/tests/integration/test_personal_data.py
@@ -1,0 +1,105 @@
+"""Integration tests for the personal-data store.
+
+Exercises the full server-side flow of ``eencijferho.io.personal_data`` against
+real MinIO + PostgreSQL instances: schema creation, UUID derivation, splitting
+records across the two secret tables and MinIO, reading back at each resolution
+level, and deleting. Skips when either backend is unavailable.
+
+Run with:
+    uv run pytest tests/integration/test_personal_data.py -v
+"""
+
+import pytest
+
+from eencijferho.io import personal_data
+
+
+@pytest.fixture
+def clean_store(personal_data_env):
+    """Ensure a fresh schema and drop any rows/files left by earlier runs."""
+    personal_data.ensure_schema()
+    pg = personal_data._pg()
+    with pg.conn.cursor() as cur:
+        cur.execute("DELETE FROM secret_sensitive")  # cascades to secret_regular
+    # Remove any lingering personal-data objects in MinIO.
+    minio = personal_data._minio()
+    for key in minio.list_files(f"{personal_data.MINIO_PREFIX}/*.json"):
+        minio.delete(key)
+    yield
+
+
+def _sample_rows():
+    return [
+        {
+            "__uuid_source": "100000009",
+            "salt": "c2FsdHNhbHRzYWx0MDE=",
+            "persoonsgebonden_nummer": "gAAAAABenc_pgn_1",
+            "burgerservice_nummer": "gAAAAABenc_bsn_1",
+            "onderwijs_nummer": "",
+            "geslacht": "M",
+            "nationaliteit_1": "NL",
+            "extra_veld": "waarde-1",
+        },
+        {
+            "__uuid_source": "100000009",  # same source -> same uuid
+            "salt": "c2FsdHNhbHRzYWx0MDI=",
+            "persoonsgebonden_nummer": "gAAAAABenc_pgn_2",
+            "burgerservice_nummer": "",
+            "onderwijs_nummer": "",
+            "geslacht": "M",
+            "extra_veld": "waarde-2",
+        },
+    ]
+
+
+def test_upload_derives_uuid_and_splits_storage(clean_store):
+    result = personal_data.upload_personal_data(_sample_rows())
+    assert result["inserted"] == 2
+    assert result["minio_file"].startswith(personal_data.MINIO_PREFIX)
+
+
+def test_uuid_source_not_persisted(clean_store):
+    """The plaintext PGN (uuid source) must never land in MinIO or the DB."""
+    result = personal_data.upload_personal_data(_sample_rows())
+    raw = personal_data.view_file(result["minio_file"], mode="raw")
+    for row in raw:
+        assert "__uuid_source" not in row
+        assert "persoonsgebonden_nummer" not in row  # sensitive stays in Postgres
+    # And the derived uuid matches server-side derivation from the source.
+    assert raw[0]["uuid"] == personal_data.derive_uuid("100000009")
+
+
+def test_same_source_yields_same_uuid(clean_store):
+    result = personal_data.upload_personal_data(_sample_rows())
+    raw = personal_data.view_file(result["minio_file"], mode="raw")
+    assert raw[0]["uuid"] == raw[1]["uuid"]
+
+
+def test_view_with_encrypted_returns_salt_and_ciphertext(clean_store):
+    result = personal_data.upload_personal_data(_sample_rows())
+    rows = personal_data.view_file(result["minio_file"], mode="with_encrypted")
+    first = rows[0]
+    assert first["salt"]  # salt returned so the browser can re-derive the key
+    assert first["persoonsgebonden_nummer"].startswith("gAAAAAB")  # still ciphertext
+
+
+def test_view_with_regular_joins_demographics(clean_store):
+    result = personal_data.upload_personal_data(_sample_rows())
+    rows = personal_data.view_file(result["minio_file"], mode="with_regular")
+    assert rows[0]["geslacht"] == "M"
+    assert "persoonsgebonden_nummer" not in rows[0]  # sensitive not in this mode
+
+
+def test_delete_removes_file_and_records(clean_store):
+    result = personal_data.upload_personal_data(_sample_rows())
+    deleted = personal_data.delete_file(result["minio_file"])
+    assert deleted["deleted_records"] >= 1
+    assert personal_data.list_minio_files() == []
+
+
+def test_list_minio_files_reflects_uploads(clean_store):
+    assert personal_data.list_minio_files() == []
+    personal_data.upload_personal_data(_sample_rows())
+    files = personal_data.list_minio_files()
+    assert len(files) == 1
+    assert files[0]["name"].startswith(personal_data.MINIO_PREFIX)

--- a/uv.lock
+++ b/uv.lock
@@ -343,6 +343,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d", size = 220838, upload-time = "2026-07-02T13:09:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe", size = 221197, upload-time = "2026-07-02T13:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/17/99fa688541ae1d6e84543a0e544f83de0c944815b63e9e7b1ed411d15036/coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c", size = 252705, upload-time = "2026-07-02T13:09:05.059Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4", size = 255441, upload-time = "2026-07-02T13:09:06.559Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5", size = 256556, upload-time = "2026-07-02T13:09:08.197Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/d3fa48489c15ecdec1ba48fd61f68798555dddd2f6716f9ad42adeb1a2a9/coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01", size = 258815, upload-time = "2026-07-02T13:09:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/2d40ddd110462c6a2769677cf7f1c119a52b45f568978fc6c98e4cc0dd0f/coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4", size = 253117, upload-time = "2026-07-02T13:09:11.212Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/310782f0d7c3cb2b5ac05ba8d205fe91f24a36f6bf3256098f1782181c38/coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796", size = 254475, upload-time = "2026-07-02T13:09:13.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/702da6c275f8ae6ade423d2877243122932c9b27f5403003b9ef8c927d12/coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382", size = 252619, upload-time = "2026-07-02T13:09:14.699Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/c5b15a7e5ecba4e56218d772d99fe80a63e63f8d11f12783723a6005ab45/coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c", size = 256689, upload-time = "2026-07-02T13:09:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2f/c8b07559b57701230c61b23a953858c052890c12ef568d81780c6c46e92e/coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766", size = 252189, upload-time = "2026-07-02T13:09:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/80/6d2f049dd3fd3dbfd60b62ba6b2162a04009e2c002ce70b24cf3878dec7a/coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da", size = 254059, upload-time = "2026-07-02T13:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/92/b0287a2c42031d25c628f815f89a3cd9f8268ee78bb1252c9356cda1c689/coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77", size = 222893, upload-time = "2026-07-02T13:09:20.812Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6", size = 223429, upload-time = "2026-07-02T13:09:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/98/6e878f0b571d32684ef3f38d7c03db241ca5b82a5da8a5391596a8f209c4/coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b", size = 222810, upload-time = "2026-07-02T13:09:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +487,7 @@ postgres = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -478,7 +518,10 @@ requires-dist = [
 provides-extras = ["frontend", "dev", "docs", "minio", "postgres", "all-backends", "demo"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+]
 
 [[package]]
 name = "entrypoints"
@@ -2293,6 +2336,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -412,6 +412,15 @@ all-backends = [
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
 ]
+demo = [
+    { name = "minio" },
+    { name = "pandas" },
+    { name = "psycopg2-binary" },
+    { name = "sqlalchemy" },
+    { name = "streamlit" },
+    { name = "streamlit-extras" },
+    { name = "streamlit-js" },
+]
 dev = [
     { name = "jupyter" },
     { name = "ruff" },
@@ -423,8 +432,10 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
 ]
 frontend = [
+    { name = "pandas" },
     { name = "streamlit" },
     { name = "streamlit-extras" },
+    { name = "streamlit-js" },
 ]
 minio = [
     { name = "minio" },
@@ -441,13 +452,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "eencijferho", extras = ["frontend"], marker = "extra == 'demo'" },
     { name = "eencijferho", extras = ["minio"], marker = "extra == 'all-backends'" },
+    { name = "eencijferho", extras = ["minio"], marker = "extra == 'demo'" },
     { name = "eencijferho", extras = ["postgres"], marker = "extra == 'all-backends'" },
+    { name = "eencijferho", extras = ["postgres"], marker = "extra == 'demo'" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "minio", marker = "extra == 'minio'", specifier = ">=7.2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26" },
     { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pandas", marker = "extra == 'frontend'", specifier = ">=2.0" },
     { name = "polars", extras = ["excel"], specifier = ">=1.21.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9" },
     { name = "rich", specifier = ">=13.9.4" },
@@ -455,11 +470,12 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "streamlit", marker = "extra == 'frontend'", specifier = ">=1.41.1" },
     { name = "streamlit-extras", marker = "extra == 'frontend'", specifier = ">=0.6.0" },
+    { name = "streamlit-js", marker = "extra == 'frontend'", specifier = ">=1.0.8" },
     { name = "sweetviz", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "xlsxwriter", specifier = ">=3.2.2" },
     { name = "ydata-profiling", marker = "extra == 'dev'", specifier = ">=4.10" },
 ]
-provides-extras = ["frontend", "dev", "docs", "minio", "postgres", "all-backends"]
+provides-extras = ["frontend", "dev", "docs", "minio", "postgres", "all-backends", "demo"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -2923,6 +2939,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/4f/270c310ec1b200914200bc8387ce166e50c247ae8e4f9e5072a8b674ba37/streamlit_image_coordinates-0.1.9.tar.gz", hash = "sha256:825e1f49053f1363913014a4e9130a03b9ca01fb5f7bd269b17afe8162d2ba37", size = 6494, upload-time = "2024-06-04T16:40:56.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/cf/1dba1380eb3b632f1f86c80533a3fca1376a938517044048122adf816a90/streamlit_image_coordinates-0.1.9-py3-none-any.whl", hash = "sha256:e577d475707ce8a3f7be1825027af6b4d7b609a456f4b25b794756ed2436ab06", size = 7049, upload-time = "2024-06-04T16:40:54.698Z" },
+]
+
+[[package]]
+name = "streamlit-js"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "streamlit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/77/e84aa98cf29572ebc49873b3d6646e4572b9f9f392cbf8b10812ee0c7264/streamlit-js-1.0.8.tar.gz", hash = "sha256:f23c1c9ff1a1ca44222a2b24cd6edf84daf6e78f5bbe07dfc87b35f7e7a16526", size = 507382, upload-time = "2024-06-07T08:57:20.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/5c/65614b858d39c28a1b0ed1690b73da4f6f061fca1d25e757bf56f3226f5b/streamlit_js-1.0.8-py3-none-any.whl", hash = "sha256:05d8447caa87abb123137f62e7e5aeed8ca83015ee170aa829280c7034a23117", size = 1631827, upload-time = "2024-06-07T08:56:57.964Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Voegt een Streamlit-demo toe waarin gebruikers CSV-data uploaden die in de browser (Pyodide) versleuteld wordt voordat deze naar MinIO en PostgreSQL gaat. Eén knop versleutelt én slaat op; downloaden van het versleutelde resultaat blijft optioneel.

## Type of Change
- [x] New feature

## Description of Changes
- **Encrypt_Upload**: versleutel een gekozen kolom client-side, sla op
- **Upload_Personal_Data**: detecteer gevoelige kolommen, leid UUID af (MD5), versleutel en splits over `secret_sensitive` / `secret_regular` (Postgres) + MinIO
- **Browse_Personal_Data**: bekijk in drie modi met client-side ontsleuteling
- **eencijferho.io.personal_data**: in-process opslaglaag via `get_backend()`
- **init.sql**: schema voor `secret_sensitive` + `secret_regular`
- **streamlit-js** toegevoegd voor synchrone JS-aanroep binnen de knop-branch

## Testing Instructions
1. `docker compose up` (start MinIO + Postgres met `init.sql`)
2. `uv run streamlit run src/main.py`
3. Upload een CSV via **Encrypt_Upload**, kies een kolom, klik versleutel + opslaan
4. Controleer via **Browse_Personal_Data** dat de data client-side weer te ontsleutelen is

## Dependencies
- `streamlit-js` (nieuw)

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the project's coding standards
